### PR TITLE
Fix concurrency issues

### DIFF
--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/Maps/SeatingMap.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/Maps/SeatingMap.java
@@ -46,7 +46,7 @@ public class SeatingMap {
         return true;
     }
 
-    public boolean bookStandingArea(String areaID, String orderId, int numberOfTickets){
+    public synchronized boolean bookStandingArea(String areaID, String orderId, int numberOfTickets){
         if(!standingAreas.containsKey(areaID)){
             return false;
         }
@@ -54,7 +54,7 @@ public class SeatingMap {
         return area.book(orderId, numberOfTickets);
     }
 
-    public boolean bookAssignedSeats(List<String> seatIDs, String orderId){
+    public synchronized boolean bookAssignedSeats(List<String> seatIDs, String orderId){
         for(String seatID : seatIDs){
             if(!seats.containsKey(seatID)){
                 return false;
@@ -74,7 +74,7 @@ public class SeatingMap {
         return true;
     }
 
-    public boolean unbookStandingArea(String areaID, int numberOfTickets){
+    public synchronized boolean unbookStandingArea(String areaID, int numberOfTickets){
         if(!standingAreas.containsKey(areaID)){
             return false;
         }
@@ -82,7 +82,7 @@ public class SeatingMap {
         return area.unbook(numberOfTickets);
     }
 
-    public boolean unbookAssignedSeats(List<String> seatIDs){
+    public synchronized boolean unbookAssignedSeats(List<String> seatIDs){
         StringBuilder failedUnbookSeats = new StringBuilder();
         for(String seatID : seatIDs){
             if(!seats.containsKey(seatID)){

--- a/src/main/java/com/ticketpurchasingsystem/project/infrastructure/EventRepo.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/infrastructure/EventRepo.java
@@ -3,6 +3,7 @@ package com.ticketpurchasingsystem.project.infrastructure;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
@@ -15,6 +16,7 @@ public class EventRepo implements IEventRepo {
 
     private final ConcurrentHashMap<String, Event> storage = new ConcurrentHashMap<>();
     private final AtomicInteger idGenerator = new AtomicInteger(1);
+    private final ConcurrentHashMap<String, ReentrantLock> eventLocks = new ConcurrentHashMap<>();
 
     // Thread-safe Singleton Implementation
     private static volatile EventRepo instance;
@@ -30,6 +32,10 @@ public class EventRepo implements IEventRepo {
         return instance;
     }
 
+    private ReentrantLock getLockFor(String eventId) {
+        return eventLocks.computeIfAbsent(eventId, id -> new ReentrantLock());
+    }
+
     @Override
     public Event save(Event event) {
         // 1. Create a brand new event
@@ -42,39 +48,54 @@ public class EventRepo implements IEventRepo {
             return new Event(event);
         }
 
-        // 2. Update an existing event
-        Event currentStored = storage.get(event.getEventId());
-        if (currentStored == null) {
-            throw new IllegalArgumentException("Event not found for update: " + event.getEventId());
+        ReentrantLock lock = getLockFor(event.getEventId());
+        lock.lock();
+        try {
+            // 2. Update an existing event
+            Event currentStored = storage.get(event.getEventId());
+            if (currentStored == null) {
+                throw new IllegalArgumentException("Event not found for update: " + event.getEventId());
+            }
+
+            // Optimistic Locking Check
+            if (event.getVersion() != currentStored.getVersion()) {
+                throw new OptimisticLockingFailureException(
+                        "Event " + event.getEventId()
+                                + ": version mismatch. Expected " + event.getVersion()
+                                + " but found " + currentStored.getVersion() + " in store.");
+            }
+
+            // Increment version on a copy of the incoming event
+            Event updated = new Event(event);
+            updated.setVersion(event.getVersion() + 1);
+
+            // Atomic replace
+            boolean replaced = storage.replace(event.getEventId(), currentStored, updated);
+            if (!replaced) {
+                throw new OptimisticLockingFailureException(
+                        "Event " + event.getEventId()
+                                + " was modified concurrently. Expected version " + event.getVersion() + ".");
+            }
+
+            return new Event(updated);
+        } finally {
+            lock.unlock();
         }
-
-        // Optimistic Locking Check
-        if (event.getVersion() != currentStored.getVersion()) {
-            throw new OptimisticLockingFailureException(
-                    "Event " + event.getEventId()
-                            + ": version mismatch. Expected " + event.getVersion()
-                            + " but found " + currentStored.getVersion() + " in store.");
-        }
-
-        // Increment version on a copy of the incoming event
-        Event updated = new Event(event);
-        updated.setVersion(event.getVersion() + 1);
-
-        // Atomic replace
-        boolean replaced = storage.replace(event.getEventId(), currentStored, updated);
-        if (!replaced) {
-            throw new OptimisticLockingFailureException(
-                    "Event " + event.getEventId()
-                            + " was modified concurrently. Expected version " + event.getVersion() + ".");
-        }
-
-        return new Event(updated);
     }
 
     @Override
     public Event findById(String eventId) {
-        Event stored = storage.get(eventId);
-        return stored != null ? new Event(stored) : null;
+        if (eventId == null) {
+            return null;
+        }
+        ReentrantLock lock = getLockFor(eventId);
+        lock.lock();
+        try {
+            Event stored = storage.get(eventId);
+            return stored != null ? new Event(stored) : null;
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
@@ -97,6 +118,20 @@ public class EventRepo implements IEventRepo {
 
     @Override
     public void delete(String eventId) {
-        storage.remove(eventId);
+        if (eventId == null) {
+            return;
+        }
+        ReentrantLock lock = eventLocks.get(eventId);
+        if (lock == null) {
+            storage.remove(eventId);
+            return;
+        }
+        lock.lock();
+        try {
+            storage.remove(eventId);
+            eventLocks.remove(eventId);
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/infrastructure/MemoryUserRepo.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/infrastructure/MemoryUserRepo.java
@@ -15,7 +15,14 @@ public class MemoryUserRepo implements IUserRepo {
 
     @Override
     public void store(UserInfo userInfo) {
-        users.put(userInfo.getId(), userInfo);
+        UserInfo existing = users.putIfAbsent(userInfo.getId(), userInfo);
+        if (existing != null) {
+            if (existing != userInfo) {
+                throw new IllegalStateException("User already exists");
+            } else {
+                users.put(userInfo.getId(), userInfo);
+            }
+        }
     }
 
     @Override

--- a/src/test/java/com/ticketpurchasingsystem/project/acceptance/concurrency/ConcurrencyIntegrationTests.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/acceptance/concurrency/ConcurrencyIntegrationTests.java
@@ -268,6 +268,7 @@ public class ConcurrencyIntegrationTests {
 
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failureCount = new AtomicInteger(0);
+        AtomicReference<Exception> failureException = new AtomicReference<>();
 
         executor.submit(() -> {
             try {
@@ -276,6 +277,7 @@ public class ConcurrencyIntegrationTests {
                 successCount.incrementAndGet();
             } catch (Exception e) {
                 failureCount.incrementAndGet();
+                failureException.set(e);
             } finally {
                 endLatch.countDown();
             }
@@ -288,6 +290,7 @@ public class ConcurrencyIntegrationTests {
                 successCount.incrementAndGet();
             } catch (Exception e) {
                 failureCount.incrementAndGet();
+                failureException.set(e);
             } finally {
                 endLatch.countDown();
             }
@@ -297,8 +300,18 @@ public class ConcurrencyIntegrationTests {
         endLatch.await(5, TimeUnit.SECONDS);
         executor.shutdown();
 
-        // Assert both registration attempts ran
-        assertEquals(2, successCount.get() + failureCount.get(), "Both requests must be processed");
+        // Assert exactly 1 thread succeeded and 1 thread failed
+        assertEquals(1, successCount.get(), "Exactly one registration must succeed");
+        assertEquals(1, failureCount.get(), "Exactly one registration must fail");
+
+        Exception ex = failureException.get();
+        assertNotNull(ex);
+        Throwable rootCause = ex;
+        while (rootCause.getCause() != null && rootCause != rootCause.getCause()) {
+            rootCause = rootCause.getCause();
+        }
+        assertTrue(rootCause instanceof IllegalStateException, "Expected root cause to be IllegalStateException, but got " + rootCause.getClass().getName());
+        assertEquals("User already exists", rootCause.getMessage());
 
         // Assert state consistency (exactly 1 user remains in MemoryUserRepo)
         UserInfo storedUser = userRepo.findByID(sharedUserId);
@@ -308,7 +321,7 @@ public class ConcurrencyIntegrationTests {
 
     // 3. Events (Concurrent Seat Reservations)
     @Test
-    public void testConcurrentSeatReservationsAllowsDoubleBooking() throws Exception {
+    public void testConcurrentSeatReservationsPreventDoubleBooking() throws Exception {
         String userA = "user_a";
         String userB = "user_b";
         userRepo.store(new UserInfo(userA, "User A", "usera@test.com", "pass123", UserGroupDiscount.NONE));
@@ -327,6 +340,7 @@ public class ConcurrencyIntegrationTests {
 
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failureCount = new AtomicInteger(0);
+        AtomicReference<Exception> failureException = new AtomicReference<>();
 
         executor.submit(() -> {
             try {
@@ -336,6 +350,7 @@ public class ConcurrencyIntegrationTests {
                 successCount.incrementAndGet();
             } catch (Exception e) {
                 failureCount.incrementAndGet();
+                failureException.set(e);
             } finally {
                 endLatch.countDown();
             }
@@ -349,6 +364,7 @@ public class ConcurrencyIntegrationTests {
                 successCount.incrementAndGet();
             } catch (Exception e) {
                 failureCount.incrementAndGet();
+                failureException.set(e);
             } finally {
                 endLatch.countDown();
             }
@@ -358,8 +374,18 @@ public class ConcurrencyIntegrationTests {
         endLatch.await(5, TimeUnit.SECONDS);
         executor.shutdown();
 
-        int totalProcessed = successCount.get() + failureCount.get();
-        assertEquals(2, totalProcessed);
+        // Exactly one should succeed, and one should fail with IllegalStateException
+        assertEquals(1, successCount.get(), "Exactly one user must successfully reserve the seat");
+        assertEquals(1, failureCount.get(), "Exactly one user must fail to reserve the seat");
+
+        Exception ex = failureException.get();
+        assertNotNull(ex);
+        Throwable rootCause = ex;
+        while (rootCause.getCause() != null && rootCause != rootCause.getCause()) {
+            rootCause = rootCause.getCause();
+        }
+        assertTrue(rootCause instanceof IllegalStateException, "Expected root cause to be IllegalStateException, but got " + rootCause.getClass().getName());
+        assertTrue(rootCause.getMessage().contains("Failed to book all seats"), "Expected rollback message, but got " + rootCause.getMessage());
 
         // Verify the seat was successfully marked as booked in the end
         Event finalEvent = eventRepo.findById(eventId);

--- a/src/test/java/com/ticketpurchasingsystem/project/acceptance/concurrency/ConcurrencyIntegrationTests.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/acceptance/concurrency/ConcurrencyIntegrationTests.java
@@ -1,0 +1,435 @@
+package com.ticketpurchasingsystem.project.acceptance.concurrency;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.ticketpurchasingsystem.project.application.ActiveOrderService;
+import com.ticketpurchasingsystem.project.application.AuthenticationService;
+import com.ticketpurchasingsystem.project.application.EventService;
+import com.ticketpurchasingsystem.project.application.HistoryOrderService;
+import com.ticketpurchasingsystem.project.application.IActiveOrderService;
+import com.ticketpurchasingsystem.project.application.IBarCodeGateway;
+import com.ticketpurchasingsystem.project.application.IEventService;
+import com.ticketpurchasingsystem.project.application.IHistoryOrderService;
+import com.ticketpurchasingsystem.project.application.IPaymentGateway;
+import com.ticketpurchasingsystem.project.application.ProductionService;
+import com.ticketpurchasingsystem.project.application.UserService.UserPublisher;
+import com.ticketpurchasingsystem.project.application.UserService.UserService;
+import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderDTO;
+import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderEvents.*;
+import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderHandler;
+import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderItem;
+import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderListener;
+import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderPublisher;
+import com.ticketpurchasingsystem.project.domain.ActiveOrders.BarcodeDTO;
+import com.ticketpurchasingsystem.project.domain.ActiveOrders.IActiveOrderRepo;
+import com.ticketpurchasingsystem.project.domain.HistoryOrder.HistoryOrderHandler;
+import com.ticketpurchasingsystem.project.domain.HistoryOrder.HistoryOrderItem;
+import com.ticketpurchasingsystem.project.domain.HistoryOrder.HistoryOrderListener;
+import com.ticketpurchasingsystem.project.domain.HistoryOrder.IHistoryOrderRepo;
+import com.ticketpurchasingsystem.project.domain.Production.OptimisticLockingFailureException;
+import com.ticketpurchasingsystem.project.domain.User.UserGroupDiscount;
+import com.ticketpurchasingsystem.project.domain.User.UserHandler;
+import com.ticketpurchasingsystem.project.domain.User.UserInfo;
+import com.ticketpurchasingsystem.project.domain.Utils.DiscountDTO;
+import com.ticketpurchasingsystem.project.domain.Utils.EventDTO;
+import com.ticketpurchasingsystem.project.domain.Utils.HistoryOrderDTO;
+import com.ticketpurchasingsystem.project.domain.Utils.PurchasePolicyDTO;
+import com.ticketpurchasingsystem.project.domain.authentication.DomainAuthService;
+import com.ticketpurchasingsystem.project.domain.authentication.ISessionRepo;
+import com.ticketpurchasingsystem.project.domain.authentication.SessionToken;
+import com.ticketpurchasingsystem.project.domain.event.Event;
+import com.ticketpurchasingsystem.project.domain.event.EventAggregateListener;
+import com.ticketpurchasingsystem.project.domain.event.EventAggregatePublisher;
+import com.ticketpurchasingsystem.project.domain.event.IEventRepo;
+import com.ticketpurchasingsystem.project.domain.event.Maps.SeatingAreaConfig;
+import com.ticketpurchasingsystem.project.domain.event.Maps.SeatingMap;
+import com.ticketpurchasingsystem.project.domain.event.Maps.StandingAreaConfig;
+import com.ticketpurchasingsystem.project.infrastructure.ActiveOrderMemRepo;
+import com.ticketpurchasingsystem.project.infrastructure.EventRepo;
+import com.ticketpurchasingsystem.project.infrastructure.HistoryOrderRepo;
+import com.ticketpurchasingsystem.project.infrastructure.InMemorySessionRepo.InMemorySessionRepo;
+import com.ticketpurchasingsystem.project.infrastructure.MemoryUserRepo;
+
+public class ConcurrencyIntegrationTests {
+
+    private MemoryUserRepo userRepo;
+    private UserService userService;
+    private AuthenticationService authenticationService;
+    private ISessionRepo sessionRepo;
+
+    private IEventService eventService;
+    private EventAggregateListener eventListener;
+    private IEventRepo eventRepo;
+    private EventAggregatePublisher eventPublisher;
+
+    private HistoryOrderListener historyOrderListener;
+    private IHistoryOrderRepo historyOrderRepo;
+    private IHistoryOrderService historyOrderService;
+
+    private IActiveOrderRepo activeOrderRepo;
+    private ActiveOrderHandler activeOrderHandler;
+    private ActiveOrderPublisher activeOrderPublisher;
+    private ActiveOrderListener activeOrderListener;
+    private IActiveOrderService activeOrderService;
+
+    private IPaymentGateway paymentGatewayMock;
+    private IBarCodeGateway barcodeGatewayMock;
+
+    private static final String TEST_SECRET = "WESP-Group-14B-Security-Token-Key-32-Characters";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // User/Auth Setup
+        userRepo = new MemoryUserRepo();
+        sessionRepo = new InMemorySessionRepo();
+        DomainAuthService domainAuthService = new DomainAuthService(sessionRepo);
+        java.lang.reflect.Field secretField = DomainAuthService.class.getDeclaredField("secret");
+        secretField.setAccessible(true);
+        secretField.set(domainAuthService, TEST_SECRET);
+        domainAuthService.init();
+        authenticationService = new AuthenticationService(domainAuthService, sessionRepo);
+        UserHandler userHandler = new UserHandler();
+        UserPublisher userPublisher = new UserPublisher(event -> {});
+        userService = new UserService(userRepo, userHandler, authenticationService, userPublisher);
+
+        // Event Setup
+        eventRepo = new EventRepo();
+        eventPublisher = new EventAggregatePublisher(event -> {});
+        eventService = new EventService(eventRepo, eventPublisher, authenticationService);
+        eventListener = new EventAggregateListener(eventRepo, eventService);
+
+        // History Setup
+        historyOrderRepo = new HistoryOrderRepo();
+        HistoryOrderHandler historyOrderHandler = new HistoryOrderHandler();
+        ProductionService productionService = new ProductionService(authenticationService, null, null, null);
+        historyOrderService = new HistoryOrderService(historyOrderRepo, historyOrderHandler, authenticationService, productionService);
+        historyOrderListener = new HistoryOrderListener(historyOrderRepo, historyOrderService);
+
+        // Active Order Setup
+        activeOrderHandler = new ActiveOrderHandler();
+        activeOrderRepo = new ActiveOrderMemRepo();
+        activeOrderListener = new ActiveOrderListener(activeOrderRepo);
+        activeOrderPublisher = new ActiveOrderPublisher(event -> {
+            if (event instanceof IsValidEventIDEvent e) {
+                eventListener.onIsValidEventIDEvent(e);
+            } else if (event instanceof GetCompanyIdEvent e) {
+                eventListener.onGetCompanyIdEvent(e);
+            } else if (event instanceof IsUpToPolicyEvent e) {
+                eventListener.onIsUpToPolicyEvent(e);
+            } else if (event instanceof CompletedOrderEvent e) {
+                historyOrderListener.onCompletedOrder(e);
+            } else if (event instanceof SeatReleaseEvent e) {
+                eventListener.onSeatReleaseEvent(e);
+            } else if (event instanceof SeatReservationEvent e) {
+                eventListener.onSeatReservationEvent(e);
+            } else if (event instanceof StandingAreaReleaseEvent e) {
+                eventListener.onStandingAreaReleaseEvent(e);
+            } else if (event instanceof StandingAreaReservationEvent e) {
+                eventListener.onStandingAreaReservationEvent(e);
+            }
+        });
+
+        paymentGatewayMock = Mockito.mock(IPaymentGateway.class);
+        barcodeGatewayMock = Mockito.mock(IBarCodeGateway.class);
+
+        activeOrderService = new ActiveOrderService(
+                activeOrderListener,
+                activeOrderPublisher,
+                activeOrderRepo,
+                activeOrderHandler,
+                authenticationService,
+                barcodeGatewayMock
+        );
+    }
+
+    private String createTestEvent(String sessionToken) {
+        int companyId = 10;
+        String eventName = "TestEvent";
+        int eventCapacity = 50;
+        LocalDateTime eventDate = LocalDateTime.now().plusYears(1);
+        PurchasePolicyDTO purchasePolicyDTO = new PurchasePolicyDTO(0, eventCapacity, false, 0, 60, true, false);
+        List<DiscountDTO> discounts = new ArrayList<>();
+
+        EventDTO e = new EventDTO(null, companyId, eventName, eventCapacity, eventDate, true);
+        eventService.createEvent(sessionToken, e, purchasePolicyDTO, discounts);
+
+        List<EventDTO> events = eventService.searchEventsByCompany(sessionToken, companyId);
+        String eventId = events.get(0).eventId();
+
+        SeatingMap seatingMap = eventService.configureSeatingMap(
+                sessionToken,
+                List.of(new SeatingAreaConfig(1, 2, 10.0)),
+                List.of(new StandingAreaConfig(20, 10.0))
+        );
+        eventService.editEventSeatingMap(sessionToken, eventId, seatingMap);
+        return eventId;
+    }
+
+    // 1. ActiveOrders (Concurrent Finalization)
+    @Test
+    public void testConcurrentActiveOrderFinalization() throws Exception {
+        String userId = "user_finalizer";
+        userRepo.store(new UserInfo(userId, "Finalizer User", "finalizer@test.com", "pass123", UserGroupDiscount.NONE));
+        String sessionToken = authenticationService.login(userId);
+
+        String eventId = createTestEvent(sessionToken);
+
+        // Create order
+        ActiveOrderItem order = activeOrderService.createPendingOrder(new SessionToken(sessionToken, 1000), userId, eventId);
+        assertNotNull(order);
+
+        // Add some seats to make it a valid order to complete
+        Event event = eventRepo.findById(eventId);
+        List<String> seatIds = event.getSeatingMap().getSeatIds();
+        activeOrderService.addSeatsToActiveOrder(new SessionToken(sessionToken, 1000), order.getOrderId(), List.of(seatIds.get(0)));
+
+        // Mock payment and barcode systems
+        when(paymentGatewayMock.pay()).thenReturn(true);
+        when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(new BarcodeDTO("barcode-xyz")));
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(2);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        AtomicReference<Exception> failureException = new AtomicReference<>();
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                activeOrderService.completeOrder(paymentGatewayMock, new SessionToken(sessionToken, 1000), 100.0, order.getOrderId());
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+                failureException.set(e);
+            } finally {
+                endLatch.countDown();
+            }
+        });
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                activeOrderService.completeOrder(paymentGatewayMock, new SessionToken(sessionToken, 1000), 100.0, order.getOrderId());
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+                failureException.set(e);
+            } finally {
+                endLatch.countDown();
+            }
+        });
+
+        startLatch.countDown();
+        endLatch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals(1, successCount.get(), "Exactly one thread must succeed in completing the order");
+        assertEquals(1, failureCount.get(), "Exactly one thread must fail to complete the order");
+
+        Exception ex = failureException.get();
+        assertNotNull(ex);
+        assertTrue(ex instanceof IllegalStateException || ex instanceof IllegalArgumentException,
+                "Expected failure exception to be IllegalStateException or IllegalArgumentException, but was " + ex.getClass().getName());
+    }
+
+    // 2. Authentications (Duplicate Registrations)
+    @Test
+    public void testConcurrentDuplicateRegistrations() throws Exception {
+        String sharedUserId = "alice_dup";
+        String name = "Alice";
+        String password = "password123";
+        String email = "alice@dup.com";
+
+        // Get two guest sessions
+        String guestToken1 = userService.guestEntry();
+        String guestToken2 = userService.guestEntry();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(2);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                userService.registerUser(sharedUserId, name, password, email, UserGroupDiscount.NONE, guestToken1);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+            } finally {
+                endLatch.countDown();
+            }
+        });
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                userService.registerUser(sharedUserId, name, password, email, UserGroupDiscount.NONE, guestToken2);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+            } finally {
+                endLatch.countDown();
+            }
+        });
+
+        startLatch.countDown();
+        endLatch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // Assert both registration attempts ran
+        assertEquals(2, successCount.get() + failureCount.get(), "Both requests must be processed");
+
+        // Assert state consistency (exactly 1 user remains in MemoryUserRepo)
+        UserInfo storedUser = userRepo.findByID(sharedUserId);
+        assertNotNull(storedUser, "User should be registered");
+        assertEquals(sharedUserId, storedUser.getId());
+    }
+
+    // 3. Events (Concurrent Seat Reservations)
+    @Test
+    public void testConcurrentSeatReservationsAllowsDoubleBooking() throws Exception {
+        String userA = "user_a";
+        String userB = "user_b";
+        userRepo.store(new UserInfo(userA, "User A", "usera@test.com", "pass123", UserGroupDiscount.NONE));
+        userRepo.store(new UserInfo(userB, "User B", "userb@test.com", "pass123", UserGroupDiscount.NONE));
+
+        String tokenA = authenticationService.login(userA);
+        String tokenB = authenticationService.login(userB);
+
+        String eventId = createTestEvent(tokenA);
+        Event event = eventRepo.findById(eventId);
+        String seatId = event.getSeatingMap().getSeatIds().get(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(2);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                // Direct call to reserveSeats (which modifies the shared in-memory SeatingMap)
+                eventService.reserveSeats(tokenA, "order-a", eventId, List.of(seatId));
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+            } finally {
+                endLatch.countDown();
+            }
+        });
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                // Direct call to reserveSeats (which modifies the shared in-memory SeatingMap)
+                eventService.reserveSeats(tokenB, "order-b", eventId, List.of(seatId));
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+            } finally {
+                endLatch.countDown();
+            }
+        });
+
+        startLatch.countDown();
+        endLatch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        int totalProcessed = successCount.get() + failureCount.get();
+        assertEquals(2, totalProcessed);
+
+        // Verify the seat was successfully marked as booked in the end
+        Event finalEvent = eventRepo.findById(eventId);
+        assertTrue(finalEvent.getSeatingMap().getSeat(seatId).isBooked());
+    }
+
+    // 4. Events (Concurrent Base Updates with Optimistic Locking)
+    @Test
+    public void testConcurrentEventBaseUpdatesOptimisticLocking() throws Exception {
+        String userId = "event_updater";
+        userRepo.store(new UserInfo(userId, "Event Updater", "updater@test.com", "pass123", UserGroupDiscount.NONE));
+        String sessionToken = authenticationService.login(userId);
+
+        String eventId = createTestEvent(sessionToken);
+
+        // Retrieve two distinct in-memory copies of the event
+        Event eventCopy1 = eventRepo.findById(eventId);
+        Event eventCopy2 = eventRepo.findById(eventId);
+
+        assertNotNull(eventCopy1);
+        assertNotNull(eventCopy2);
+        assertEquals(eventCopy1.getVersion(), eventCopy2.getVersion());
+
+        // Modify both copies
+        eventCopy1.setEventCapacity(100);
+        eventCopy2.setEventCapacity(200);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(2);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        AtomicReference<Exception> optLockException = new AtomicReference<>();
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                eventRepo.save(eventCopy1);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+                optLockException.set(e);
+            } finally {
+                endLatch.countDown();
+            }
+        });
+
+        executor.submit(() -> {
+            try {
+                startLatch.await();
+                eventRepo.save(eventCopy2);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failureCount.incrementAndGet();
+                optLockException.set(e);
+            } finally {
+                endLatch.countDown();
+            }
+        });
+
+        startLatch.countDown();
+        endLatch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // Assert that optimistic locking succeeds on one and throws an OptimisticLockingFailureException on the other
+        assertEquals(1, successCount.get());
+        assertEquals(1, failureCount.get());
+        assertNotNull(optLockException.get());
+        assertTrue(optLockException.get() instanceof OptimisticLockingFailureException,
+                "Expected OptimisticLockingFailureException but got: " + optLockException.get().getClass().getName());
+    }
+}


### PR DESCRIPTION
follow-up to the concurrency testing branch. 
* Fixed the duplicate registration overwrite by swapping a .put() for a thread-safe .putIfAbsent() in MemoryUserRepo.
* Blocked the seat double-bookings by making the core reservation edits synchronized right inside SeatingMap.

The multi-threaded tests are now updated to explicitly enforce these rules. I ran the full test suite locally and they all pass now.