### PR TITLE
refactor(notification): move all logic to domain, clean up service layer

### DIFF
--- a/src/main/java/com/ticketpurchasingsystem/project/Controllers/NotificationController.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/Controllers/NotificationController.java
@@ -15,10 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ticketpurchasingsystem.project.Controllers.apidto.BroadcastNotificationRequestDTO;
 import com.ticketpurchasingsystem.project.Controllers.apidto.CreateNotificationRequestDTO;
-import com.ticketpurchasingsystem.project.application.ForbiddenException;
 import com.ticketpurchasingsystem.project.application.INotificationService;
-import com.ticketpurchasingsystem.project.application.NotFoundException;
 import com.ticketpurchasingsystem.project.application.UnauthorizedException;
+import com.ticketpurchasingsystem.project.domain.exceptions.ForbiddenException;
+import com.ticketpurchasingsystem.project.domain.exceptions.NotFoundException;
 import com.ticketpurchasingsystem.project.domain.Utils.NotificationDTO;
 
 @RestController

--- a/src/main/java/com/ticketpurchasingsystem/project/application/NotificationService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/NotificationService.java
@@ -1,187 +1,67 @@
 package com.ticketpurchasingsystem.project.application;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
 import com.ticketpurchasingsystem.project.domain.HistoryOrder.IHistoryOrderRepo;
 import com.ticketpurchasingsystem.project.domain.Production.IProdRepo;
-import com.ticketpurchasingsystem.project.domain.Production.ProductionCompany;
 import com.ticketpurchasingsystem.project.domain.Utils.NotificationDTO;
-import com.ticketpurchasingsystem.project.domain.event.Event;
 import com.ticketpurchasingsystem.project.domain.event.IEventRepo;
 import com.ticketpurchasingsystem.project.domain.notification.INotificationRepo;
-import com.ticketpurchasingsystem.project.domain.notification.Notification;
+import com.ticketpurchasingsystem.project.domain.notification.NotificationHandler;
 
 @Service
 public class NotificationService implements INotificationService {
 
-    private final INotificationRepo notificationRepo;
-    private final AuthenticationService authenticationService;
-    private final IHistoryOrderRepo historyOrderRepo;
-    private final IProdRepo prodRepo;
-    private final IEventRepo eventRepo;
-    private final AtomicLong idCounter = new AtomicLong(0);
+    private final NotificationHandler notificationHandler;
 
     public NotificationService(INotificationRepo notificationRepo,
                                AuthenticationService authenticationService,
                                IHistoryOrderRepo historyOrderRepo,
                                IProdRepo prodRepo,
                                IEventRepo eventRepo) {
-        this.notificationRepo = notificationRepo;
-        this.authenticationService = authenticationService;
-        this.historyOrderRepo = historyOrderRepo;
-        this.prodRepo = prodRepo;
-        this.eventRepo = eventRepo;
-    }
-
-    private String nextId() {
-        return "NOTIF-" + idCounter.incrementAndGet();
-    }
-
-    private NotificationDTO toDTO(Notification n) {
-        return new NotificationDTO(n.getId(), n.getUserId(), n.getMessage(), n.isRead(), n.getCreatedAt());
-    }
-
-    private void requireValidToken(String token) {
-        if (!authenticationService.validate(token)) {
-            throw new UnauthorizedException("Invalid session token");
-        }
-    }
-
-    private void requireOwnerOrManager(ProductionCompany company, String callerId) {
-        if (!company.getOwnerIds().contains(callerId) && !company.getManagerTree().containsKey(callerId)) {
-            throw new ForbiddenException("Caller is not an owner or manager of this production company");
-        }
-    }
-
-    private NotificationDTO saveFor(String userId, String message) {
-        Notification notification = new Notification(nextId(), userId, message);
-        notificationRepo.save(notification);
-        return toDTO(notification);
+        this.notificationHandler = NotificationHandler.getInstance(notificationRepo, authenticationService,
+                historyOrderRepo, prodRepo, eventRepo);
     }
 
     @Override
     public NotificationDTO createNotification(String token, String targetUserId, String message) {
-        requireValidToken(token);
-        if (!authenticationService.isAdmin(token)) {
-            throw new ForbiddenException("Only administrators can send targeted notifications");
-        }
-        if (targetUserId == null || targetUserId.isBlank()) {
-            throw new IllegalArgumentException("Target user ID must not be empty");
-        }
-        if (message == null || message.isBlank()) {
-            throw new IllegalArgumentException("Message must not be empty");
-        }
-        return saveFor(targetUserId, message);
+        return notificationHandler.createNotification(token, targetUserId, message);
     }
 
     @Override
     public List<NotificationDTO> createNotificationsForEvent(String token, String eventId, String message) {
-        requireValidToken(token);
-        if (eventId == null || eventId.isBlank()) {
-            throw new IllegalArgumentException("Event ID must not be empty");
-        }
-        if (message == null || message.isBlank()) {
-            throw new IllegalArgumentException("Message must not be empty");
-        }
-        Event event = eventRepo.findById(eventId);
-        if (event == null) {
-            throw new NotFoundException("Event not found: " + eventId);
-        }
-        ProductionCompany company = prodRepo.findById(event.getCompanyId())
-                .orElseThrow(() -> new NotFoundException("Production company not found: " + event.getCompanyId()));
-        String caller = authenticationService.getUser(token);
-        requireOwnerOrManager(company, caller);
-
-        Set<String> userIds = historyOrderRepo.findAllByEventId(eventId).stream()
-                .map(order -> order.getUserId())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        List<NotificationDTO> created = new ArrayList<>();
-        for (String userId : userIds) {
-            created.add(saveFor(userId, message));
-        }
-        return created;
+        return notificationHandler.createNotificationsForEvent(token, eventId, message);
     }
 
     @Override
     public List<NotificationDTO> createNotificationsForProduction(String token, int companyId, String message) {
-        requireValidToken(token);
-        if (message == null || message.isBlank()) {
-            throw new IllegalArgumentException("Message must not be empty");
-        }
-        ProductionCompany company = prodRepo.findById(companyId)
-                .orElseThrow(() -> new NotFoundException("Production company not found: " + companyId));
-        String caller = authenticationService.getUser(token);
-        requireOwnerOrManager(company, caller);
-
-        Set<String> userIds = new LinkedHashSet<>(company.getOwnerIds());
-        userIds.addAll(company.getManagerTree().keySet());
-
-        List<NotificationDTO> created = new ArrayList<>();
-        for (String userId : userIds) {
-            created.add(saveFor(userId, message));
-        }
-        return created;
+        return notificationHandler.createNotificationsForProduction(token, companyId, message);
     }
 
     @Override
     public List<NotificationDTO> getNotificationsForUser(String token) {
-        requireValidToken(token);
-        String userId = authenticationService.getUser(token);
-        return notificationRepo.findByUserId(userId).stream()
-                .map(this::toDTO)
-                .collect(Collectors.toList());
+        return notificationHandler.getNotificationsForUser(token);
     }
 
     @Override
     public NotificationDTO getNotificationById(String token, String notificationId) {
-        requireValidToken(token);
-        Notification notification = notificationRepo.findById(notificationId);
-        if (notification == null) {
-            throw new NotFoundException("Notification not found");
-        }
-        String userId = authenticationService.getUser(token);
-        if (!notification.getUserId().equals(userId)) {
-            throw new ForbiddenException("Access denied: notification belongs to another user");
-        }
-        return toDTO(notification);
+        return notificationHandler.getNotificationById(token, notificationId);
     }
 
     @Override
     public boolean markAsRead(String token, String notificationId) {
-        requireValidToken(token);
-        Notification notification = notificationRepo.findById(notificationId);
-        if (notification == null) {
-            throw new NotFoundException("Notification not found");
-        }
-        String userId = authenticationService.getUser(token);
-        if (!notification.getUserId().equals(userId)) {
-            throw new ForbiddenException("Access denied: notification belongs to another user");
-        }
-        return notification.markAsRead();
+        return notificationHandler.markAsRead(token, notificationId);
     }
 
     @Override
     public NotificationDTO createSystemNotification(String targetUserId, String message) {
-        if (targetUserId == null || targetUserId.isBlank()) {
-            throw new IllegalArgumentException("Target user ID must not be empty");
-        }
-        if (message == null || message.isBlank()) {
-            throw new IllegalArgumentException("Message must not be empty");
-        }
-        return saveFor(targetUserId, message);
+        return notificationHandler.createSystemNotification(targetUserId, message);
     }
 
     @Override
     public long getUnreadCount(String token) {
-        requireValidToken(token);
-        String userId = authenticationService.getUser(token);
-        return notificationRepo.countUnreadByUserId(userId);
+        return notificationHandler.getUnreadCount(token);
     }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/exceptions/ForbiddenException.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/exceptions/ForbiddenException.java
@@ -1,4 +1,4 @@
-package com.ticketpurchasingsystem.project.application;
+package com.ticketpurchasingsystem.project.domain.exceptions;
 
 public class ForbiddenException extends RuntimeException {
     public ForbiddenException(String message) {

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/exceptions/NotFoundException.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/exceptions/NotFoundException.java
@@ -1,4 +1,4 @@
-package com.ticketpurchasingsystem.project.application;
+package com.ticketpurchasingsystem.project.domain.exceptions;
 
 public class NotFoundException extends RuntimeException {
     public NotFoundException(String message) {

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/notification/INotificationRepo.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/notification/INotificationRepo.java
@@ -1,10 +1,11 @@
 package com.ticketpurchasingsystem.project.domain.notification;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface INotificationRepo {
     void save(Notification notification);
-    Notification findById(String id);
+    Optional<Notification> findById(String id);
     List<Notification> findByUserId(String userId);
     long countUnreadByUserId(String userId);
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/notification/Notification.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/notification/Notification.java
@@ -3,6 +3,9 @@ package com.ticketpurchasingsystem.project.domain.notification;
 import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.ticketpurchasingsystem.project.domain.Utils.NotificationDTO;
+import com.ticketpurchasingsystem.project.domain.exceptions.ForbiddenException;
+
 public class Notification {
     private final String id;
     private final String userId;
@@ -11,6 +14,8 @@ public class Notification {
     private final LocalDateTime createdAt;
 
     public Notification(String id, String userId, String message) {
+        if (userId == null || userId.isBlank()) throw new IllegalArgumentException("Target user ID must not be empty");
+        if (message == null || message.isBlank()) throw new IllegalArgumentException("Message must not be empty");
         this.id = id;
         this.userId = userId;
         this.message = message;
@@ -24,4 +29,14 @@ public class Notification {
     public LocalDateTime getCreatedAt() { return createdAt; }
 
     public boolean markAsRead() { return read.compareAndSet(false, true); }
+
+    public void requireOwnedBy(String userId) {
+        if (!this.userId.equals(userId)) {
+            throw new ForbiddenException("Access denied: notification belongs to another user");
+        }
+    }
+
+    public NotificationDTO toDTO() {
+        return new NotificationDTO(id, userId, message, read.get(), createdAt);
+    }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationHandler.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationHandler.java
@@ -1,0 +1,150 @@
+package com.ticketpurchasingsystem.project.domain.notification;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import com.ticketpurchasingsystem.project.application.AuthenticationService;
+import com.ticketpurchasingsystem.project.domain.HistoryOrder.IHistoryOrderRepo;
+import com.ticketpurchasingsystem.project.domain.Production.IProdRepo;
+import com.ticketpurchasingsystem.project.domain.Production.ProductionCompany;
+import com.ticketpurchasingsystem.project.domain.Utils.NotificationDTO;
+import com.ticketpurchasingsystem.project.domain.event.Event;
+import com.ticketpurchasingsystem.project.domain.event.IEventRepo;
+import com.ticketpurchasingsystem.project.domain.exceptions.ForbiddenException;
+import com.ticketpurchasingsystem.project.domain.exceptions.NotFoundException;
+
+public class NotificationHandler {
+
+    private static volatile NotificationHandler instance;
+
+    private INotificationRepo notificationRepo;
+    private AuthenticationService authenticationService;
+    private IHistoryOrderRepo historyOrderRepo;
+    private IProdRepo prodRepo;
+    private IEventRepo eventRepo;
+    private final AtomicLong idCounter = new AtomicLong(0);
+
+    private NotificationHandler(INotificationRepo notificationRepo,
+                                AuthenticationService authenticationService,
+                                IHistoryOrderRepo historyOrderRepo,
+                                IProdRepo prodRepo,
+                                IEventRepo eventRepo) {
+        this.notificationRepo = notificationRepo;
+        this.authenticationService = authenticationService;
+        this.historyOrderRepo = historyOrderRepo;
+        this.prodRepo = prodRepo;
+        this.eventRepo = eventRepo;
+    }
+
+    public static NotificationHandler getInstance(INotificationRepo notificationRepo,
+                                                  AuthenticationService authenticationService,
+                                                  IHistoryOrderRepo historyOrderRepo,
+                                                  IProdRepo prodRepo,
+                                                  IEventRepo eventRepo) {
+        if (instance == null) {
+            synchronized (NotificationHandler.class) {
+                if (instance == null) {
+                    instance = new NotificationHandler(notificationRepo, authenticationService,
+                            historyOrderRepo, prodRepo, eventRepo);
+                }
+            }
+        }
+        instance.notificationRepo = notificationRepo;
+        instance.authenticationService = authenticationService;
+        instance.historyOrderRepo = historyOrderRepo;
+        instance.prodRepo = prodRepo;
+        instance.eventRepo = eventRepo;
+        return instance;
+    }
+
+    private String nextId() {
+        return "NOTIF-" + idCounter.incrementAndGet();
+    }
+
+    private void requireValidToken(String token) {
+        if (!authenticationService.validate(token)) {
+            throw new com.ticketpurchasingsystem.project.application.UnauthorizedException("Invalid session token");
+        }
+    }
+
+    private NotificationDTO saveFor(String userId, String message) {
+        Notification notification = new Notification(nextId(), userId, message);
+        notificationRepo.save(notification);
+        return notification.toDTO();
+    }
+
+    public NotificationDTO createNotification(String token, String targetUserId, String message) {
+        requireValidToken(token);
+        if (!authenticationService.isAdmin(token)) {
+            throw new ForbiddenException("Only administrators can send targeted notifications");
+        }
+        return saveFor(targetUserId, message);
+    }
+
+    public List<NotificationDTO> createNotificationsForEvent(String token, String eventId, String message) {
+        requireValidToken(token);
+        Event event = eventRepo.findById(eventId);
+        if (event == null) {
+            throw new NotFoundException("Event not found: " + eventId);
+        }
+        ProductionCompany company = prodRepo.findById(event.getCompanyId())
+                .orElseThrow(() -> new NotFoundException("Production company not found: " + event.getCompanyId()));
+        if (!company.isOwnerOrManager(authenticationService.getUser(token))) {
+            throw new ForbiddenException("Caller is not an owner or manager of this production company");
+        }
+        return historyOrderRepo.findAllByEventId(eventId).stream()
+                .map(order -> order.getUserId())
+                .collect(Collectors.toCollection(LinkedHashSet::new))
+                .stream()
+                .map(userId -> saveFor(userId, message))
+                .collect(Collectors.toList());
+    }
+
+    public List<NotificationDTO> createNotificationsForProduction(String token, int companyId, String message) {
+        requireValidToken(token);
+        ProductionCompany company = prodRepo.findById(companyId)
+                .orElseThrow(() -> new NotFoundException("Production company not found: " + companyId));
+        if (!company.isOwnerOrManager(authenticationService.getUser(token))) {
+            throw new ForbiddenException("Caller is not an owner or manager of this production company");
+        }
+        LinkedHashSet<String> userIds = new LinkedHashSet<>(company.getOwnerIds());
+        userIds.addAll(company.getManagerTree().keySet());
+        return userIds.stream()
+                .map(userId -> saveFor(userId, message))
+                .collect(Collectors.toList());
+    }
+
+    public List<NotificationDTO> getNotificationsForUser(String token) {
+        requireValidToken(token);
+        return notificationRepo.findByUserId(authenticationService.getUser(token)).stream()
+                .map(Notification::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public NotificationDTO getNotificationById(String token, String notificationId) {
+        requireValidToken(token);
+        Notification notification = notificationRepo.findById(notificationId)
+                .orElseThrow(() -> new NotFoundException("Notification not found"));
+        notification.requireOwnedBy(authenticationService.getUser(token));
+        return notification.toDTO();
+    }
+
+    public boolean markAsRead(String token, String notificationId) {
+        requireValidToken(token);
+        Notification notification = notificationRepo.findById(notificationId)
+                .orElseThrow(() -> new NotFoundException("Notification not found"));
+        notification.requireOwnedBy(authenticationService.getUser(token));
+        return notification.markAsRead();
+    }
+
+    public NotificationDTO createSystemNotification(String targetUserId, String message) {
+        return saveFor(targetUserId, message);
+    }
+
+    public long getUnreadCount(String token) {
+        requireValidToken(token);
+        return notificationRepo.countUnreadByUserId(authenticationService.getUser(token));
+    }
+}

--- a/src/main/java/com/ticketpurchasingsystem/project/infrastructure/InMemoryNotificationRepo.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/infrastructure/InMemoryNotificationRepo.java
@@ -2,6 +2,7 @@ package com.ticketpurchasingsystem.project.infrastructure;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Repository;
@@ -19,8 +20,8 @@ public class InMemoryNotificationRepo implements INotificationRepo {
     }
 
     @Override
-    public Notification findById(String id) {
-        return store.get(id);
+    public Optional<Notification> findById(String id) {
+        return Optional.ofNullable(store.get(id));
     }
 
     @Override

--- a/src/test/java/com/ticketpurchasingsystem/project/Controllers/NotificationControllerTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/Controllers/NotificationControllerTest.java
@@ -24,10 +24,10 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.ticketpurchasingsystem.project.application.ForbiddenException;
 import com.ticketpurchasingsystem.project.application.INotificationService;
-import com.ticketpurchasingsystem.project.application.NotFoundException;
 import com.ticketpurchasingsystem.project.application.UnauthorizedException;
+import com.ticketpurchasingsystem.project.domain.exceptions.ForbiddenException;
+import com.ticketpurchasingsystem.project.domain.exceptions.NotFoundException;
 import com.ticketpurchasingsystem.project.domain.Utils.NotificationDTO;
 
 @WebMvcTest(NotificationController.class)

--- a/src/test/java/com/ticketpurchasingsystem/project/acceptance/notification/NotificationAcceptanceTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/acceptance/notification/NotificationAcceptanceTest.java
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.ticketpurchasingsystem.project.application.AuthenticationService;
-import com.ticketpurchasingsystem.project.application.ForbiddenException;
-import com.ticketpurchasingsystem.project.application.NotFoundException;
+import com.ticketpurchasingsystem.project.domain.exceptions.ForbiddenException;
+import com.ticketpurchasingsystem.project.domain.exceptions.NotFoundException;
 import com.ticketpurchasingsystem.project.application.NotificationService;
 import com.ticketpurchasingsystem.project.application.UnauthorizedException;
 import com.ticketpurchasingsystem.project.domain.Utils.NotificationDTO;

--- a/src/test/java/com/ticketpurchasingsystem/project/application/NotificationServiceTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/application/NotificationServiceTest.java
@@ -24,6 +24,8 @@ import com.ticketpurchasingsystem.project.domain.Production.ProductionCompany;
 import com.ticketpurchasingsystem.project.domain.Utils.NotificationDTO;
 import com.ticketpurchasingsystem.project.domain.event.Event;
 import com.ticketpurchasingsystem.project.domain.event.IEventRepo;
+import com.ticketpurchasingsystem.project.domain.exceptions.ForbiddenException;
+import com.ticketpurchasingsystem.project.domain.exceptions.NotFoundException;
 import com.ticketpurchasingsystem.project.domain.notification.INotificationRepo;
 import com.ticketpurchasingsystem.project.domain.notification.Notification;
 
@@ -120,7 +122,7 @@ class NotificationServiceTest {
         when(eventRepo.findById(EVENT_ID)).thenReturn(mockEvent);
         when(mockEvent.getCompanyId()).thenReturn(COMPANY_ID);
         when(prodRepo.findById(COMPANY_ID)).thenReturn(Optional.of(mockCompany));
-        when(mockCompany.getOwnerIds()).thenReturn(List.of(USER_ID));
+        when(mockCompany.isOwnerOrManager(USER_ID)).thenReturn(true);
         when(historyOrderRepo.findAllByEventId(EVENT_ID)).thenReturn(List.of());
 
         List<NotificationDTO> result = notificationService.createNotificationsForEvent(VALID_TOKEN, EVENT_ID, MESSAGE);
@@ -136,8 +138,7 @@ class NotificationServiceTest {
         when(eventRepo.findById(EVENT_ID)).thenReturn(mockEvent);
         when(mockEvent.getCompanyId()).thenReturn(COMPANY_ID);
         when(prodRepo.findById(COMPANY_ID)).thenReturn(Optional.of(mockCompany));
-        when(mockCompany.getOwnerIds()).thenReturn(List.of());
-        when(mockCompany.getManagerTree()).thenReturn(java.util.Collections.emptyMap());
+        when(mockCompany.isOwnerOrManager(USER_ID)).thenReturn(false);
 
         assertThrows(ForbiddenException.class, () ->
                 notificationService.createNotificationsForEvent(VALID_TOKEN, EVENT_ID, MESSAGE));
@@ -169,6 +170,7 @@ class NotificationServiceTest {
         when(authenticationService.validate(VALID_TOKEN)).thenReturn(true);
         when(authenticationService.getUser(VALID_TOKEN)).thenReturn(USER_ID);
         when(prodRepo.findById(COMPANY_ID)).thenReturn(Optional.of(mockCompany));
+        when(mockCompany.isOwnerOrManager(USER_ID)).thenReturn(true);
         when(mockCompany.getOwnerIds()).thenReturn(List.of(USER_ID));
         when(mockCompany.getManagerTree()).thenReturn(java.util.Collections.emptyMap());
 
@@ -182,8 +184,7 @@ class NotificationServiceTest {
         when(authenticationService.validate(VALID_TOKEN)).thenReturn(true);
         when(authenticationService.getUser(VALID_TOKEN)).thenReturn(USER_ID);
         when(prodRepo.findById(COMPANY_ID)).thenReturn(Optional.of(mockCompany));
-        when(mockCompany.getOwnerIds()).thenReturn(List.of());
-        when(mockCompany.getManagerTree()).thenReturn(java.util.Collections.emptyMap());
+        when(mockCompany.isOwnerOrManager(USER_ID)).thenReturn(false);
 
         assertThrows(ForbiddenException.class, () ->
                 notificationService.createNotificationsForProduction(VALID_TOKEN, COMPANY_ID, MESSAGE));
@@ -239,7 +240,7 @@ class NotificationServiceTest {
         Notification n = new Notification("NOTIF-1", USER_ID, MESSAGE);
         when(authenticationService.validate(VALID_TOKEN)).thenReturn(true);
         when(authenticationService.getUser(VALID_TOKEN)).thenReturn(USER_ID);
-        when(notificationRepo.findById("NOTIF-1")).thenReturn(n);
+        when(notificationRepo.findById("NOTIF-1")).thenReturn(Optional.of(n));
 
         NotificationDTO result = notificationService.getNotificationById(VALID_TOKEN, "NOTIF-1");
 
@@ -250,7 +251,7 @@ class NotificationServiceTest {
     @Test
     void GivenNotificationNotFound_WhenGetById_ThenThrow() {
         when(authenticationService.validate(VALID_TOKEN)).thenReturn(true);
-        when(notificationRepo.findById("NOTIF-X")).thenReturn(null);
+        when(notificationRepo.findById("NOTIF-X")).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class, () ->
                 notificationService.getNotificationById(VALID_TOKEN, "NOTIF-X"));
@@ -261,7 +262,7 @@ class NotificationServiceTest {
         Notification n = new Notification("NOTIF-1", OTHER_USER_ID, MESSAGE);
         when(authenticationService.validate(VALID_TOKEN)).thenReturn(true);
         when(authenticationService.getUser(VALID_TOKEN)).thenReturn(USER_ID);
-        when(notificationRepo.findById("NOTIF-1")).thenReturn(n);
+        when(notificationRepo.findById("NOTIF-1")).thenReturn(Optional.of(n));
 
         assertThrows(ForbiddenException.class, () ->
                 notificationService.getNotificationById(VALID_TOKEN, "NOTIF-1"));
@@ -274,7 +275,7 @@ class NotificationServiceTest {
         Notification n = new Notification("NOTIF-1", USER_ID, MESSAGE);
         when(authenticationService.validate(VALID_TOKEN)).thenReturn(true);
         when(authenticationService.getUser(VALID_TOKEN)).thenReturn(USER_ID);
-        when(notificationRepo.findById("NOTIF-1")).thenReturn(n);
+        when(notificationRepo.findById("NOTIF-1")).thenReturn(Optional.of(n));
 
         boolean result = notificationService.markAsRead(VALID_TOKEN, "NOTIF-1");
 
@@ -288,7 +289,7 @@ class NotificationServiceTest {
         n.markAsRead();
         when(authenticationService.validate(VALID_TOKEN)).thenReturn(true);
         when(authenticationService.getUser(VALID_TOKEN)).thenReturn(USER_ID);
-        when(notificationRepo.findById("NOTIF-1")).thenReturn(n);
+        when(notificationRepo.findById("NOTIF-1")).thenReturn(Optional.of(n));
 
         boolean result = notificationService.markAsRead(VALID_TOKEN, "NOTIF-1");
 
@@ -301,7 +302,7 @@ class NotificationServiceTest {
         Notification n = new Notification("NOTIF-1", OTHER_USER_ID, MESSAGE);
         when(authenticationService.validate(VALID_TOKEN)).thenReturn(true);
         when(authenticationService.getUser(VALID_TOKEN)).thenReturn(USER_ID);
-        when(notificationRepo.findById("NOTIF-1")).thenReturn(n);
+        when(notificationRepo.findById("NOTIF-1")).thenReturn(Optional.of(n));
 
         assertThrows(ForbiddenException.class, () ->
                 notificationService.markAsRead(VALID_TOKEN, "NOTIF-1"));
@@ -311,7 +312,7 @@ class NotificationServiceTest {
     @Test
     void GivenNotificationNotFound_WhenMarkAsRead_ThenThrow() {
         when(authenticationService.validate(VALID_TOKEN)).thenReturn(true);
-        when(notificationRepo.findById("NOTIF-X")).thenReturn(null);
+        when(notificationRepo.findById("NOTIF-X")).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class, () ->
                 notificationService.markAsRead(VALID_TOKEN, "NOTIF-X"));
@@ -392,7 +393,6 @@ class NotificationServiceTest {
 
     @Test
     void GivenValidArgs_WhenCreateSystemNotification_ThenNoTokenRequired() {
-        // System notifications bypass auth — no stubbing of authenticationService needed
         NotificationDTO result = notificationService.createSystemNotification(USER_ID, MESSAGE);
 
         assertNotNull(result);


### PR DESCRIPTION
- Extract all business logic from NotificationService into NotificationHandler (domain), matching the EventHandler/EventService pattern
- Notification constructor now validates userId and message; adds requireOwnedBy() and toDTO() domain methods
- Move ForbiddenException and NotFoundException to domain/exceptions; delete empty application-layer wrappers
- INotificationRepo.findById returns Optional<Notification>; InMemoryNotificationRepo updated accordingly
- NotificationService is now a pure thin delegate to NotificationHandler
- Update NotificationController, all tests, and acceptance tests to use domain exceptions