### PR TITLE
248 display admin error

### DIFF
--- a/frontend/src/api/adminApi.ts
+++ b/frontend/src/api/adminApi.ts
@@ -64,7 +64,9 @@ export const adminApi = {
             headers: getHeaders(token),
         });
 
-        return parseResponse(response);
+        const data = await parseResponse(response);
+        if (!Array.isArray(data)) throw new Error("Active orders response is not an array.");
+        return data;
     },
 
     getOrderHistory: async (token: string): Promise<SystemHistoryOrderDTO[]> => {
@@ -73,7 +75,9 @@ export const adminApi = {
             headers: getHeaders(token),
         });
 
-        return parseResponse(response);
+        const data = await parseResponse(response);
+        if (!Array.isArray(data)) throw new Error("History orders response is not an array.");
+        return data;
     },
 
     getSystemUsers: async (token: string): Promise<SystemUserDTO[]> => {
@@ -82,7 +86,9 @@ export const adminApi = {
             headers: getHeaders(token),
         });
 
-        return parseResponse(response);
+        const data = await parseResponse(response);
+        if (!Array.isArray(data)) throw new Error("Users response is not an array.");
+        return data;
     },
 };
 

--- a/frontend/src/api/adminApi.ts
+++ b/frontend/src/api/adminApi.ts
@@ -31,8 +31,7 @@ export type SystemUserDTO = {
   username?: string;
   name?: string;
   email?: string;
-  userState?: string;
-  groupDiscount?: string;
+  userGroupDiscount?: string;
   [key: string]: unknown;
 };
 

--- a/frontend/src/pages/admin/AdminPage.tsx
+++ b/frontend/src/pages/admin/AdminPage.tsx
@@ -239,7 +239,7 @@ function AdminUsersTable({ users }: { users: SystemUserDTO[] }) {
               <th>User ID</th>
               <th>Name</th>
               <th>Email</th>
-              <th>State</th>
+              <th>Group Discount</th>
             </tr>
           </thead>
 
@@ -249,7 +249,7 @@ function AdminUsersTable({ users }: { users: SystemUserDTO[] }) {
                 <td>{String(user.id ?? user.userId ?? "—")}</td>
                 <td>{String(user.username ?? user.name ?? "—")}</td>
                 <td>{String(user.email ?? "—")}</td>
-                <td>{String(user.userState ?? "—")}</td>
+                <td>{String(user.userGroupDiscount ?? "—")}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/pages/admin/AdminPage.tsx
+++ b/frontend/src/pages/admin/AdminPage.tsx
@@ -12,7 +12,7 @@ type AdminDataState = {
 };
 
 export default function AdminPage() {
-  const { token, isAdmin } = useAuth();
+  const { token, isAdmin, loading: authLoading } = useAuth();
 
   const [selectedTab, setSelectedTab] = useState<AdminTab>("overview");
   const [data, setData] = useState<AdminDataState>({
@@ -32,6 +32,8 @@ export default function AdminPage() {
   }, [data.historyOrders]);
 
   useEffect(() => {
+    if (authLoading) return;
+
     if (!token || !isAdmin) {
       setErrorMessage("Access denied: admin privileges required.");
       return;
@@ -61,7 +63,7 @@ export default function AdminPage() {
     };
 
     loadAdminData();
-  }, [token, isAdmin]);
+  }, [token, isAdmin, authLoading]);
 
   return (
     <section className="admin-page">

--- a/frontend/src/pages/admin/AdminPage.tsx
+++ b/frontend/src/pages/admin/AdminPage.tsx
@@ -33,6 +33,7 @@ export default function AdminPage() {
 
   useEffect(() => {
     if (!token || !isAdmin) {
+      setErrorMessage("Access denied: admin privileges required.");
       return;
     }
 
@@ -42,9 +43,9 @@ export default function AdminPage() {
 
       try {
         const [users, activeOrders, historyOrders] = await Promise.all([
-          adminApi.getSystemUsers(token),
-          adminApi.getActiveOrders(token),
-          adminApi.getOrderHistory(token),
+          adminApi.getSystemUsers(token).catch(e => { throw new Error(`Users: ${e.message}`); }),
+          adminApi.getActiveOrders(token).catch(e => { throw new Error(`Active orders: ${e.message}`); }),
+          adminApi.getOrderHistory(token).catch(e => { throw new Error(`History orders: ${e.message}`); }),
         ]);
 
         setData({
@@ -80,11 +81,14 @@ export default function AdminPage() {
         </div>
       )}
 
+      {!errorMessage && (
+        <>
       <div className="admin-page__stats-grid">
         <button
           type="button"
           className="admin-page__stat-card"
           onClick={() => setSelectedTab("users")}
+          disabled={loading}
         >
           <span className="admin-page__stat-label">Users</span>
           <strong className="admin-page__stat-value">{data.users.length}</strong>
@@ -94,6 +98,7 @@ export default function AdminPage() {
           type="button"
           className="admin-page__stat-card"
           onClick={() => setSelectedTab("activeOrders")}
+          disabled={loading}
         >
           <span className="admin-page__stat-label">Active Orders</span>
           <strong className="admin-page__stat-value">
@@ -105,6 +110,7 @@ export default function AdminPage() {
           type="button"
           className="admin-page__stat-card"
           onClick={() => setSelectedTab("historyOrders")}
+          disabled={loading}
         >
           <span className="admin-page__stat-label">History Orders</span>
           <strong className="admin-page__stat-value">
@@ -181,6 +187,8 @@ export default function AdminPage() {
           />
         )}
       </div>
+        </>
+      )}
     </section>
   );
 }
@@ -264,30 +272,37 @@ function AdminGenericTable({
     return <p className="admin-page__muted">{emptyMessage}</p>;
   }
 
-  const columns = Array.from(
+  const allColumns = Array.from(
     items.reduce((keys, item) => {
       Object.keys(item).forEach((key) => keys.add(key));
       return keys;
     }, new Set<string>())
-  ).slice(0, 8);
+  );
+  const truncated = allColumns.length > 8;
+  const columns = allColumns.slice(0, 8);
 
   return (
     <div>
       <h2>{title}</h2>
+      {truncated && (
+        <p className="admin-page__muted">
+          Showing 8 of {allColumns.length} columns.
+        </p>
+      )}
 
       <div className="admin-page__table-wrapper">
         <table className="admin-page__table">
           <thead>
             <tr>
               {columns.map((column) => (
-                <th key={column}>{column}</th>
+                <th key={column}>{formatColumnLabel(column)}</th>
               ))}
             </tr>
           </thead>
 
           <tbody>
             {items.map((item, index) => (
-              <tr key={String(item.orderId ?? index)}>
+              <tr key={String(item.orderId ?? item.id ?? index)}>
                 {columns.map((column) => (
                   <td key={column}>{formatCellValue(item[column])}</td>
                 ))}
@@ -298,6 +313,13 @@ function AdminGenericTable({
       </div>
     </div>
   );
+}
+
+function formatColumnLabel(key: string): string {
+  return key
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (c) => c.toUpperCase())
+    .trim();
 }
 
 function formatCellValue(value: unknown): string {


### PR DESCRIPTION
No "Access denied" flash — waits for auth to finish loading before checking isAdmin
Stats grid and tabs hidden entirely when there's an error
Stat buttons disabled during loading
Columns past 8 show a notice instead of silently disappearing
Row keys fall back to item.id before index
Column headers display as readable text (purchaseDate → Purchase Date)
State column removed (backend doesn't send it)
Group Discount reads userGroupDiscount (correct field name)
adminApi.ts

Each API call validates the response is an array before returning — crashes with a clear message instead of silently breaking
SystemUserDTO type matches what the backend actually sends