### PR TITLE
Example for making Acceptance Tests use a DB repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,1 +1,11 @@
 init.file=init_db_file.txt
+
+# H2 in-memory database for dev
+spring.datasource.url=jdbc:h2:mem:ticketdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,1 +1,10 @@
 init.file=empty_init.txt
+
+# PostgreSQL remote database for production
+spring.datasource.url=jdbc:postgresql://${DB_HOST}:${DB_PORT:5432}/${DB_NAME}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWORD}
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=validate
+spring.h2.console.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,13 +4,4 @@ jwt.secret=myUltraSecretKeyForJWTSigningThatIsAtLeast32CharactersLong
 spring.security.user.name=user
 spring.security.user.password=409e2525-e72e-4d5c-bedd-2b9d7af70449
 
-# H2 in-memory database
-spring.datasource.url=jdbc:h2:mem:ticketdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.hibernate.ddl-auto=update
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
 spring.security.headers.frame-options.config=sameorigin

--- a/src/test/java/com/ticketpurchasingsystem/project/acceptance/production/AppointManagerAcceptanceTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/acceptance/production/AppointManagerAcceptanceTest.java
@@ -9,11 +9,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketpurchasingsystem.project.application.AuthenticationService;
 import com.ticketpurchasingsystem.project.application.ProductionService;
-import com.ticketpurchasingsystem.project.application.SystemAdminService;
+import com.ticketpurchasingsystem.project.domain.Production.IProdRepo;
 import com.ticketpurchasingsystem.project.domain.Production.ManagerPermission;
 import com.ticketpurchasingsystem.project.domain.Production.ProductionCompany;
 import com.ticketpurchasingsystem.project.domain.Production.ProductionEventPublisher;
@@ -21,9 +25,12 @@ import com.ticketpurchasingsystem.project.domain.Production.ProductionEvents.IsU
 import com.ticketpurchasingsystem.project.domain.Production.ProductionHandler;
 import com.ticketpurchasingsystem.project.domain.Utils.ProductionCompanyDTO;
 import com.ticketpurchasingsystem.project.domain.authentication.DomainAuthService;
+import com.ticketpurchasingsystem.project.domain.authentication.ISessionRepo;
 import com.ticketpurchasingsystem.project.infrastructure.InMemorySessionRepo.InMemorySessionRepo;
-import com.ticketpurchasingsystem.project.infrastructure.ProdRepo;
 
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional // rolls back DB changes after each test method
 class AppointManagerAcceptanceTest {
 
     private static final String TEST_SECRET = "my-test-secret-key-for-jwt-testing-only!";
@@ -35,20 +42,25 @@ class AppointManagerAcceptanceTest {
 
     private final Set<String> registeredUsers = new HashSet<>();
 
+@Autowired
+private IProdRepo prodRepo;
+
+
+private ISessionRepo sessionRepo;
+
     private AuthenticationService authService;
-    private ProdRepo prodRepo;
     private ProductionService productionService;
     private int companyId;
 
     @BeforeEach
     void setUp() {
         registeredUsers.clear();
-        InMemorySessionRepo sessionRepo = new InMemorySessionRepo();
+        sessionRepo = new InMemorySessionRepo();
         DomainAuthService domainAuthService = new DomainAuthService(sessionRepo);
         ReflectionTestUtils.setField(domainAuthService, "secret", TEST_SECRET);
         domainAuthService.init();
         authService = new AuthenticationService(domainAuthService, sessionRepo);
-        prodRepo = new ProdRepo();
+
         ProductionEventPublisher publisher = new ProductionEventPublisher(event -> {
             if (event instanceof IsUserRegisteredEvent e) {
                 e.setRegistered(registeredUsers.contains(e.getUserId()));
@@ -64,84 +76,63 @@ class AppointManagerAcceptanceTest {
 
     @Test
     void GivenOwnerAppoints_WhenAppointManager_ThenReturnTrue() {
-        // Arrange
         registeredUsers.add(MANAGER_ID);
         String founderToken = authService.login(FOUNDER);
 
-        // Act
         boolean result = productionService.appointManager(founderToken, companyId, MANAGER_ID, PERMISSIONS);
 
-        // Assert
         assertTrue(result);
     }
 
     @Test
     void GivenOwnerAppoints_WhenAppointManager_ThenManagerAppearsInCompany() {
-        // Arrange
         registeredUsers.add(MANAGER_ID);
         String founderToken = authService.login(FOUNDER);
 
-        // Act
         productionService.appointManager(founderToken, companyId, MANAGER_ID, PERMISSIONS);
 
-        // Assert
         Optional<ProductionCompany> company = prodRepo.findByName("Events Co");
         assertTrue(company.isPresent());
         assertTrue(company.get().isManager(MANAGER_ID));
     }
 
-    // Fail
-
     @Test
     void GivenInvalidToken_WhenAppointManager_ThenReturnFalse() {
-        // Arrange
         registeredUsers.add(MANAGER_ID);
 
-        // Act
         boolean result = productionService.appointManager("bad-token", companyId, MANAGER_ID, PERMISSIONS);
 
-        // Assert
         assertFalse(result);
     }
 
     @Test
     void GivenNonOwnerAppoints_WhenAppointManager_ThenReturnFalse() {
-        // Arrange
         registeredUsers.add(MANAGER_ID);
         String nonOwnerToken = authService.login("random-user");
 
-        // Act
         boolean result = productionService.appointManager(nonOwnerToken, companyId, MANAGER_ID, PERMISSIONS);
 
-        // Assert
         assertFalse(result);
     }
 
     @Test
     void GivenManagerAlreadyAppointed_WhenAppointManager_ThenReturnFalse() {
-        // Arrange
         registeredUsers.add(MANAGER_ID);
         String founderToken = authService.login(FOUNDER);
         productionService.appointManager(founderToken, companyId, MANAGER_ID, PERMISSIONS);
 
-        // Act
         String newToken = authService.login(FOUNDER);
         boolean secondResult = productionService.appointManager(newToken, companyId, MANAGER_ID, PERMISSIONS);
 
-        // Assert
         assertFalse(secondResult);
     }
 
     @Test
     void GivenUnregisteredManager_WhenAppointManager_ThenReturnFalse() {
-        // Arrange
         String founderToken = authService.login(FOUNDER);
-        // "unregistered" is intentionally NOT added to registeredUsers
 
-        // Act
         boolean result = productionService.appointManager(founderToken, companyId, "unregistered", PERMISSIONS);
 
-        // Assert
         assertFalse(result);
     }
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,5 +1,6 @@
 # Empty init — no seed data during tests
 init.file=empty_init.txt
+jwt.secret=myUltraSecretKeyForJWTSigningThatIsAtLeast32CharactersLong
 
 # Isolated H2 in-memory DB for tests (separate from dev)
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,11 @@
+# Empty init — no seed data during tests
+init.file=empty_init.txt
+
+# Isolated H2 in-memory DB for tests (separate from dev)
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.h2.console.enabled=false

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=test


### PR DESCRIPTION
Here i made AppointManagerAcceptanceTest use the ProdDBRepo instead of the InMemoryOne and its is also conencted to a H2 DB of its own through the application-test.properties in src/test/resources

IMPORTANT:
dont accept this PR before the PR of tomer: create Prod profile....
i still need to add the connection to DBSessionRepo here, will do after it will be merged into main