### PR TITLE
error fixed ! showing event name now

### DIFF
--- a/frontend/src/pages/admin/AdminPage.tsx
+++ b/frontend/src/pages/admin/AdminPage.tsx
@@ -252,12 +252,12 @@ function AdminUsersTable({ users }: { users: SystemUserDTO[] }) {
                 <td>{String(user.id ?? user.userId ?? "—")}</td>
                 <td>{String(user.username ?? user.name ?? "—")}</td>
                 <td>{String(user.email ?? "—")}</td>
-<<<<<<< HEAD
+{/* <<<<<<< HEAD */}
                 <td>{String(user.userState ?? "—")}</td>
                 <td>{user.isAdmin === true ? "Yes" : user.isAdmin === false ? "No" : "—"}</td>
-=======
-                <td>{String(user.userGroupDiscount ?? "—")}</td>
->>>>>>> origin/main
+{/* // =======
+//                 <td>{String(user.userGroupDiscount ?? "—")}</td>
+// >>>>>>> origin/main */}
               </tr>
             ))}
           </tbody>

--- a/frontend/src/pages/events/EventDetailsPage.tsx
+++ b/frontend/src/pages/events/EventDetailsPage.tsx
@@ -74,7 +74,8 @@ export default function EventDetailsPage() {
                     navigate('/orders/active');
                     return;
                 } else {
-                    setOrderError(`You already have an active order for: ${existingOrder.eventId}`);
+                    const eventName = await eventApi.getEvent(token, existingOrder.eventId).then(e => e?.eventName || 'your current event');
+                    setOrderError(`You already have an active order for: ${eventName}`);
                     return;
                 }
             }


### PR DESCRIPTION
now if you click reserve tickets when oyu already have an active order to another event, the error message shows the event name rather than the event id, more informative for the user