### PR TITLE
fixed immediate logout on refresh

### DIFF
--- a/src/main/java/com/ticketpurchasingsystem/project/application/UserService/UserService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/UserService/UserService.java
@@ -190,11 +190,11 @@ public class UserService implements IUserService {
                 authenticationService.removeSessionManually(token);
                 userPublisher.publishGuestExited(userId, token);
             } else {
-                userInfo.setLoggedIn(false);
-                userInfo.setSessionTokenStr(null);
-                userRepo.store(userInfo);
-                authenticationService.removeSessionManually(token);
-                userPublisher.publishUserLoggedOut(userId, token);
+//                userInfo.setLoggedIn(false);
+//                userInfo.setSessionTokenStr(null);
+//                userRepo.store(userInfo);
+//                authenticationService.removeSessionManually(token);
+//                userPublisher.publishUserLoggedOut(userId, token);
             }
             loggerDef.getInstance().info("Handled irregular disconnect for user: " + userId);
         } catch (Exception e) {

--- a/src/test/java/com/ticketpurchasingsystem/project/acceptance/user/UserAcceptanceTests.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/acceptance/user/UserAcceptanceTests.java
@@ -327,19 +327,22 @@ class UserAcceptanceTests {
                 "a wrong-password re-login must not drop the existing session");
     }
 
-    @Test
-    void GivenLoggedInMember_WhenHandleDisconnect_ThenLoggedOutAndSessionRemoved() {
-        // Simulates the WebSocket disconnect callback (browser closed without Exit).
-        String session = registerAndLogin();
 
-        userService.handleDisconnect(USER_ID, session);
-
-        UserInfo member = userRepo.findByID(USER_ID);
-        assertFalse(member.isLoggedIn(), "an irregular disconnect must log the member out");
-        assertNull(member.getSessionTokenStr());
-        assertTrue(sessionRepo.findByToken(session).isEmpty(),
-                "the dropped connection's session must be removed");
-    }
+    ///in this branch i the immediate logout was a problem, we changed it so that the logout is not immediate,
+    /// but its when the session is expired and purgeExpiredSessions runs, so this test becomes irrelevant
+//    @Test
+//    void GivenLoggedInMember_WhenHandleDisconnect_ThenLoggedOutAndSessionRemoved() {
+//        // Simulates the WebSocket disconnect callback (browser closed without Exit).
+//        String session = registerAndLogin();
+//
+//        userService.handleDisconnect(USER_ID, session);
+//
+//        UserInfo member = userRepo.findByID(USER_ID);
+//        assertFalse(member.isLoggedIn(), "an irregular disconnect must log the member out");
+//        assertNull(member.getSessionTokenStr());
+//        assertTrue(sessionRepo.findByToken(session).isEmpty(),
+//                "the dropped connection's session must be removed");
+//    }
 
     @Test
     void GivenMemberReLoggedInUnderNewToken_WhenStaleDisconnectArrives_ThenIgnored() {


### PR DESCRIPTION
- changed handleDisconnect to not disconnect the logged in user immediately, this is what caused the problem because on each refresh the websocket thought the connection closed for a milisecond and called the handleDisconnect method
- removed irrelevant test according to this change

now what happens is the user stays logged in until the session token related to this user has expired and purgeExpiredSession is called (its called every 30 minutes currently). even if the user stays logged in he isnt locked out of his account because two things can happen:
1. he is still on the session from before and it wasnt deleted, then he isnt even prompted to log in, he is already logged in.
2. he is on a different session from the one which is related to him in the DB, then his session in the  DB gets replaced in loginUser() in UserHandler and his current session becomes the session associated with the user and it lets him into the website

this was what causes issues #304 and #305
so closes #304 and closes #305