### PR TITLE
refund rollback happens when cancelling or error during payment

### DIFF
--- a/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
@@ -293,7 +293,7 @@ public class ActiveOrderService implements IActiveOrderService {
             if(barcodesIssued == null){
                 throw new IllegalStateException("Barcode generation failed");
             }
-            activeOrderPublisher.publishCompletedOrder(orderDTO, amount, companyId);
+            activeOrderPublisher.publishCompletedOrder(orderDTO, amount, companyId, transactionId);
             activeOrderRepo.delete(orderId);
             logger.info("Successfully completed order: " + orderId);
             return barcodesIssued;

--- a/src/main/java/com/ticketpurchasingsystem/project/application/HistoryOrderService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/HistoryOrderService.java
@@ -38,8 +38,8 @@ public class HistoryOrderService implements IHistoryOrderService {
 
     @Override
     @Transactional
-    public boolean createHistoryOrder(String orderId, String userId, String eventId, int companyId, Timestamp purchaseDate, double price, List<String> seatIds, HashMap<String, Integer> standingAreaQuantities) {
-        HistoryOrderDTO historyOrderDTO = new HistoryOrderDTO(orderId, userId, eventId, companyId, purchaseDate, price, seatIds, standingAreaQuantities);
+    public boolean createHistoryOrder(String orderId, String userId, String eventId, int companyId, Timestamp purchaseDate, double price, List<String> seatIds, HashMap<String, Integer> standingAreaQuantities, Integer transactionId) {
+        HistoryOrderDTO historyOrderDTO = new HistoryOrderDTO(orderId, userId, eventId, companyId, purchaseDate, price, seatIds, standingAreaQuantities, transactionId);
         HistoryOrderItem newHistoryOrder = historyOrderHandler.saveHistoryOrder(historyOrderDTO);
         if (newHistoryOrder != null) {
             historyOrderRepo.save(newHistoryOrder);

--- a/src/main/java/com/ticketpurchasingsystem/project/application/IHistoryOrderService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/IHistoryOrderService.java
@@ -8,7 +8,10 @@ import com.ticketpurchasingsystem.project.domain.Utils.HistoryOrderDTO;
 import com.ticketpurchasingsystem.project.domain.authentication.SessionToken;
 
 public interface IHistoryOrderService {
-    public boolean createHistoryOrder(String orderId, String userId, String eventId, int companyId, Timestamp purchaseDate, double price, List<String> seatIds, HashMap<String, Integer> standingAreaQuantities);
+    public boolean createHistoryOrder(String orderId, String userId, String eventId, int companyId, Timestamp purchaseDate, double price, List<String> seatIds, HashMap<String, Integer> standingAreaQuantities, Integer transactionId);
+    default public boolean createHistoryOrder(String orderId, String userId, String eventId, int companyId, Timestamp purchaseDate, double price, List<String> seatIds, HashMap<String, Integer> standingAreaQuantities) {
+        return createHistoryOrder(orderId, userId, eventId, companyId, purchaseDate, price, seatIds, standingAreaQuantities, null);
+    }
     public HistoryOrderDTO getHistoryOrder(SessionToken sessionToken, String orderId);
     public List<HistoryOrderDTO> getAllHistoryOrdersByUser(SessionToken sessionToken,String userASk);
     public List<HistoryOrderDTO> getAllHistoryOrdersByCompany(SessionToken sessionToken, int companyId);

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderEvents/CompletedOrderEvent.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderEvents/CompletedOrderEvent.java
@@ -8,12 +8,18 @@ public class CompletedOrderEvent extends ApplicationEvent {
     private ActiveOrderDTO order;
     private int companyId;
     private double amountPaid;
-    public CompletedOrderEvent(Object source, ActiveOrderDTO order, double amountPaid ,int companyId){
+    private int transactionId;
+
+    public CompletedOrderEvent(Object source, ActiveOrderDTO order, double amountPaid, int companyId, int transactionId) {
         super(source);
         this.order = order;
         this.amountPaid = amountPaid;
         this.companyId = companyId;
+        this.transactionId = transactionId;
+    }
 
+    public CompletedOrderEvent(Object source, ActiveOrderDTO order, double amountPaid, int companyId) {
+        this(source, order, amountPaid, companyId, -1);
     }
 
     public ActiveOrderDTO getOrder() {
@@ -26,5 +32,9 @@ public class CompletedOrderEvent extends ApplicationEvent {
 
     public int getCompanyId() {
         return companyId;
+    }
+
+    public int getTransactionId() {
+        return transactionId;
     }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderPublisher.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderPublisher.java
@@ -55,9 +55,12 @@ public class ActiveOrderPublisher {
         eventPublisher.publishEvent(event);
         return event.getResult();
     }
-    public void publishCompletedOrder(ActiveOrderDTO order, double amountPaid, int companyId){
-        CompletedOrderEvent event = new CompletedOrderEvent(this, order, amountPaid, companyId);
+    public void publishCompletedOrder(ActiveOrderDTO order, double amountPaid, int companyId, int transactionId){
+        CompletedOrderEvent event = new CompletedOrderEvent(this, order, amountPaid, companyId, transactionId);
         eventPublisher.publishEvent(event);
+    }
+    public void publishCompletedOrder(ActiveOrderDTO order, double amountPaid, int companyId){
+        publishCompletedOrder(order, amountPaid, companyId, -1);
     }
     public Integer publishGetCompanyId(String eventId){
         GetCompanyIdEvent event = new GetCompanyIdEvent(this, eventId);

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/HistoryOrder/HistoryOrderItem.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/HistoryOrder/HistoryOrderItem.java
@@ -52,9 +52,12 @@ public class HistoryOrderItem {
     @Column(name = "quantity")
     private Map<String, Integer> StandingAreaQuantities;
 
+    @Column(name = "transaction_id")
+    private Integer transactionId;
+
     public HistoryOrderItem() {}
 
-    public HistoryOrderItem(String orderId, String userId, String eventId, int companyId, double price, List<String> seatIds, Map<String, Integer> standingAreaQuantities) {
+    public HistoryOrderItem(String orderId, String userId, String eventId, int companyId, double price, List<String> seatIds, Map<String, Integer> standingAreaQuantities, Integer transactionId) {
         this.orderId = orderId;
         this.userId = userId;
         this.eventId = eventId;
@@ -63,6 +66,11 @@ public class HistoryOrderItem {
         this.price = price;
         this.seatIds = new ArrayList<>(seatIds);
         this.StandingAreaQuantities = new HashMap<>(standingAreaQuantities);
+        this.transactionId = transactionId;
+    }
+
+    public HistoryOrderItem(String orderId, String userId, String eventId, int companyId, double price, List<String> seatIds, Map<String, Integer> standingAreaQuantities) {
+        this(orderId, userId, eventId, companyId, price, seatIds, standingAreaQuantities, null);
     }
 
     public HistoryOrderItem(HistoryOrderDTO dto) {
@@ -74,6 +82,7 @@ public class HistoryOrderItem {
         this.price = dto.getPrice();
         this.seatIds = new ArrayList<>(dto.getSeatIds());
         this.StandingAreaQuantities = new HashMap<>(dto.getStandingAreaQuantities());
+        this.transactionId = dto.getTransactionId();
     }
 
     public String getOrderId() { return orderId; }
@@ -104,8 +113,11 @@ public class HistoryOrderItem {
         this.StandingAreaQuantities = standingAreaQuantities;
     }
 
+    public Integer getTransactionId() { return transactionId; }
+    public void setTransactionId(Integer transactionId) { this.transactionId = transactionId; }
+
     public HistoryOrderDTO makeDTO() {
-        return new HistoryOrderDTO(orderId, userId, eventId, companyId, purchaseDate, price, seatIds, getStandingAreaQuantities());
+        return new HistoryOrderDTO(orderId, userId, eventId, companyId, purchaseDate, price, seatIds, getStandingAreaQuantities(), transactionId);
     }
 }
 

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/HistoryOrder/HistoryOrderListener.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/HistoryOrder/HistoryOrderListener.java
@@ -36,6 +36,6 @@ public class HistoryOrderListener {
     @EventListener
     public void onCompletedOrder(CompletedOrderEvent event){
         ActiveOrderDTO order = event.getOrder();
-        historyOrderService.createHistoryOrder(order.getOrderId(), order.getUserId(), order.getEventId(), event.getCompanyId(), Timestamp.from(java.time.Instant.now()), event.getAmountPaid(), order.getSeatIds(), order.getStandingAreaQuantities());
+        historyOrderService.createHistoryOrder(order.getOrderId(), order.getUserId(), order.getEventId(), event.getCompanyId(), Timestamp.from(java.time.Instant.now()), event.getAmountPaid(), order.getSeatIds(), order.getStandingAreaQuantities(), event.getTransactionId());
     }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/Utils/HistoryOrderDTO.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/Utils/HistoryOrderDTO.java
@@ -13,8 +13,9 @@ public class HistoryOrderDTO {
     public double price;
     public List<String> seatIds;
     public HashMap<String, Integer> StandingAreaQuantities;
+    public Integer transactionId;
 
-    public HistoryOrderDTO(String orderId, String userId, String eventId, int companyId, Timestamp purchaseDate, double price, List<String> seatIds, HashMap<String, Integer> standingAreaQuantities) {
+    public HistoryOrderDTO(String orderId, String userId, String eventId, int companyId, Timestamp purchaseDate, double price, List<String> seatIds, HashMap<String, Integer> standingAreaQuantities, Integer transactionId) {
         this.orderId = orderId;
         this.userId = userId;
         this.eventId = eventId;
@@ -23,6 +24,11 @@ public class HistoryOrderDTO {
         this.price = price;
         this.seatIds = seatIds;
         this.StandingAreaQuantities = standingAreaQuantities;
+        this.transactionId = transactionId;
+    }
+
+    public HistoryOrderDTO(String orderId, String userId, String eventId, int companyId, Timestamp purchaseDate, double price, List<String> seatIds, HashMap<String, Integer> standingAreaQuantities) {
+        this(orderId, userId, eventId, companyId, purchaseDate, price, seatIds, standingAreaQuantities, null);
     }
 
     public String getOrderId() { return orderId; }
@@ -33,4 +39,5 @@ public class HistoryOrderDTO {
     public double getPrice() { return price; }
     public List<String> getSeatIds() { return seatIds; }
     public HashMap<String, Integer> getStandingAreaQuantities() { return StandingAreaQuantities; }
+    public Integer getTransactionId() { return transactionId; }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListener.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListener.java
@@ -99,11 +99,11 @@ public class NotificationEventListener {
                 try {
                     paymentGateway.refund(order.getTransactionId());
                     logger.info("Successfully refunded transaction " + order.getTransactionId() + " for order " + order.getOrderId());
-                    String successMessage = "The event has been canceled and your payment has been fully refunded.";
+                    String successMessage = String.format("Event \"%s\" has been canceled and your payment of %.2f for order %s has been fully refunded.", event.getEventName(), order.getPrice(), order.getOrderId());
                     notificationService.createSystemNotification(order.getUserId(), successMessage);
                 } catch (Exception e) {
                     logger.error("Failed to refund transaction " + order.getTransactionId() + " for order " + order.getOrderId());
-                    String failMessage = "The event has been canceled, but your automatic refund could not be processed. Please contact customer service for assistance.";
+                    String failMessage = String.format("Event \"%s\" has been canceled, but your automatic refund of %.2f for order %s could not be processed. Please contact customer service for assistance.", event.getEventName(), order.getPrice(), order.getOrderId());
                     notificationService.createSystemNotification(order.getUserId(), failMessage);
                 }
             } else {

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListener.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListener.java
@@ -93,21 +93,27 @@ public class NotificationEventListener {
     @EventListener
     public void onEventCancelled(EventCancelledEvent event) {
         java.util.List<HistoryOrderItem> orders = historyOrderRepo.findAllByEventId(event.getEventId());
-        Set<String> buyers = new LinkedHashSet<>();
+        Set<String> buyersWithDefaultNotification = new LinkedHashSet<>();
         for (HistoryOrderItem order : orders) {
-            buyers.add(order.getUserId());
             if (order.getTransactionId() != null && order.getTransactionId() != -1) {
                 try {
                     paymentGateway.refund(order.getTransactionId());
+                    logger.info("Successfully refunded transaction " + order.getTransactionId() + " for order " + order.getOrderId());
+                    String successMessage = "The event has been canceled and your payment has been fully refunded.";
+                    notificationService.createSystemNotification(order.getUserId(), successMessage);
                 } catch (Exception e) {
-                    logger.error("Failed to refund transaction ID " + order.getTransactionId() + " for order " + order.getOrderId() + ": " + e.getMessage());
+                    logger.error("Failed to refund transaction " + order.getTransactionId() + " for order " + order.getOrderId());
+                    String failMessage = "The event has been canceled, but your automatic refund could not be processed. Please contact customer service for assistance.";
+                    notificationService.createSystemNotification(order.getUserId(), failMessage);
                 }
+            } else {
+                buyersWithDefaultNotification.add(order.getUserId());
             }
         }
-        String message = String.format(
+        String defaultMessage = String.format(
                 "Event \"%s\" has been cancelled.", event.getEventName());
-        for (String userId : buyers) {
-            notificationService.createSystemNotification(userId, message);
+        for (String userId : buyersWithDefaultNotification) {
+            notificationService.createSystemNotification(userId, defaultMessage);
         }
     }
 

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListener.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListener.java
@@ -97,8 +97,11 @@ public class NotificationEventListener {
         for (HistoryOrderItem order : orders) {
             if (order.getTransactionId() != null && order.getTransactionId() != -1) {
                 try {
-                    paymentGateway.refund(order.getTransactionId());
-                    logger.info("Successfully refunded transaction " + order.getTransactionId() + " for order " + order.getOrderId());
+                    int originalTxId = order.getTransactionId();
+                    paymentGateway.refund(originalTxId);
+                    order.setTransactionId(-1);
+                    historyOrderRepo.save(order);
+                    logger.info("Successfully refunded transaction " + originalTxId + " for order " + order.getOrderId());
                     String successMessage = String.format("Event \"%s\" has been canceled and your payment of %.2f for order %s has been fully refunded.", event.getEventName(), order.getPrice(), order.getOrderId());
                     notificationService.createSystemNotification(order.getUserId(), successMessage);
                 } catch (Exception e) {

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListener.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListener.java
@@ -16,6 +16,8 @@ import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderEvents.
 import java.util.Objects;
 
 import com.ticketpurchasingsystem.project.domain.HistoryOrder.IHistoryOrderRepo;
+import com.ticketpurchasingsystem.project.domain.HistoryOrder.HistoryOrderItem;
+import com.ticketpurchasingsystem.project.application.IPaymentGateway;
 import com.ticketpurchasingsystem.project.domain.Production.ProductionEvents.AppointmentRequestedEvent;
 import com.ticketpurchasingsystem.project.domain.event.Event;
 import com.ticketpurchasingsystem.project.domain.event.IEventRepo;
@@ -30,16 +32,19 @@ public class NotificationEventListener {
     private final AuthenticationService authenticationService;
     private final IHistoryOrderRepo historyOrderRepo;
     private final IEventRepo eventRepo;
+    private final IPaymentGateway paymentGateway;
     private final loggerDef logger = loggerDef.getInstance();
 
     public NotificationEventListener(INotificationService notificationService,
                                      AuthenticationService authenticationService,
                                      IHistoryOrderRepo historyOrderRepo,
-                                     IEventRepo eventRepo) {
+                                     IEventRepo eventRepo,
+                                     IPaymentGateway paymentGateway) {
         this.notificationService = notificationService;
         this.authenticationService = authenticationService;
         this.historyOrderRepo = Objects.requireNonNull(historyOrderRepo, "historyOrderRepo must not be null");
         this.eventRepo = Objects.requireNonNull(eventRepo, "eventRepo must not be null");
+        this.paymentGateway = Objects.requireNonNull(paymentGateway, "paymentGateway must not be null");
     }
 
     @EventListener
@@ -87,9 +92,18 @@ public class NotificationEventListener {
 
     @EventListener
     public void onEventCancelled(EventCancelledEvent event) {
+        java.util.List<HistoryOrderItem> orders = historyOrderRepo.findAllByEventId(event.getEventId());
         Set<String> buyers = new LinkedHashSet<>();
-        historyOrderRepo.findAllByEventId(event.getEventId())
-                .forEach(order -> buyers.add(order.getUserId()));
+        for (HistoryOrderItem order : orders) {
+            buyers.add(order.getUserId());
+            if (order.getTransactionId() != null && order.getTransactionId() != -1) {
+                try {
+                    paymentGateway.refund(order.getTransactionId());
+                } catch (Exception e) {
+                    logger.error("Failed to refund transaction ID " + order.getTransactionId() + " for order " + order.getOrderId() + ": " + e.getMessage());
+                }
+            }
+        }
         String message = String.format(
                 "Event \"%s\" has been cancelled.", event.getEventName());
         for (String userId : buyers) {

--- a/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
@@ -736,7 +736,7 @@ public class ActiveOrderServiceUnitTest {
 
         assertNotNull(result);
         verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
-        verify(activeOrderPublisherMock, times(1)).publishCompletedOrder(any(ActiveOrderDTO.class), eq(AMOUNT), eq(COMPANY_ID));
+        verify(activeOrderPublisherMock, times(1)).publishCompletedOrder(any(ActiveOrderDTO.class), eq(AMOUNT), eq(COMPANY_ID), eq(50000));
     }
 
     @Test
@@ -757,7 +757,7 @@ public class ActiveOrderServiceUnitTest {
 
         assertNotNull(result);
         verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
-        verify(activeOrderPublisherMock, times(1)).publishCompletedOrder(any(ActiveOrderDTO.class), eq(AMOUNT), eq(COMPANY_ID));
+        verify(activeOrderPublisherMock, times(1)).publishCompletedOrder(any(ActiveOrderDTO.class), eq(AMOUNT), eq(COMPANY_ID), eq(50000));
     }
 
     @Test
@@ -842,7 +842,7 @@ public class ActiveOrderServiceUnitTest {
         verify(activeOrderPublisherMock, times(1)).publishReleaseSeats(VALID_TOKEN, ORDER_ID, EVENT_ID, List.of("B-10", "B-11"));
         verify(activeOrderPublisherMock, times(1)).publishReleaseStandingArea(VALID_TOKEN, EVENT_ID, "VIP-1", 2);
         verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
-        verify(activeOrderPublisherMock, never()).publishCompletedOrder(any(), anyDouble(), anyInt());
+        verify(activeOrderPublisherMock, never()).publishCompletedOrder(any(), anyDouble(), anyInt(), anyInt());
     }
 
 
@@ -870,7 +870,7 @@ public class ActiveOrderServiceUnitTest {
         verify(paymentGatewayMock, times(1)).refund(100);
         verify(activeOrderPublisherMock, times(1)).publishReleaseSeats(VALID_TOKEN, ORDER_ID, EVENT_ID, List.of("C-1"));
         verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
-        verify(activeOrderPublisherMock, never()).publishCompletedOrder(any(), anyDouble(), anyInt());
+        verify(activeOrderPublisherMock, never()).publishCompletedOrder(any(), anyDouble(), anyInt(), anyInt());
     }
 
     @Test
@@ -891,7 +891,7 @@ public class ActiveOrderServiceUnitTest {
 
         doThrow(new RuntimeException("Persistence failed"))
                 .when(activeOrderPublisherMock)
-                .publishCompletedOrder(any(), anyDouble(), anyInt());
+                .publishCompletedOrder(any(), anyDouble(), anyInt(), anyInt());
 
         when(activeOrderHandlerMock.canReleaseSeats(validOrder.getSeatIds())).thenReturn(true);
         lenient().when(activeOrderHandlerMock.canReleaseStanding(validOrder.getStandingAreaQuantities())).thenReturn(true);

--- a/src/test/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListenerTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListenerTest.java
@@ -228,9 +228,25 @@ class NotificationEventListenerTest {
 
         verify(paymentGateway).refund(12345);
         verify(paymentGateway, never()).refund(-1);
-        verify(notificationService).createSystemNotification(eq(USER_ID), contains("Rock Concert"));
+        verify(notificationService).createSystemNotification(eq(USER_ID), eq("The event has been canceled and your payment has been fully refunded."));
         verify(notificationService).createSystemNotification(eq("user-002"), contains("Rock Concert"));
         verify(notificationService).createSystemNotification(eq("user-003"), contains("Rock Concert"));
+    }
+
+    @Test
+    void GivenFailedRefund_WhenOnEventCancelled_ThenNotifyFailureAndContinue() {
+        HistoryOrderItem order1 = new HistoryOrderItem("ORD-001", USER_ID, EVENT_ID, 1, 50.0, List.of(), new HashMap<>(), 12345);
+        HistoryOrderItem order2 = new HistoryOrderItem("ORD-002", "user-002", EVENT_ID, 1, 50.0, List.of(), new HashMap<>(), 67890);
+        when(historyOrderRepo.findAllByEventId(EVENT_ID)).thenReturn(List.of(order1, order2));
+
+        when(paymentGateway.refund(12345)).thenThrow(new RuntimeException("Gateway offline"));
+
+        listener.onEventCancelled(new EventCancelledEvent(EVENT_ID, "Rock Concert"));
+
+        verify(paymentGateway).refund(12345);
+        verify(paymentGateway).refund(67890);
+        verify(notificationService).createSystemNotification(eq(USER_ID), eq("The event has been canceled, but your automatic refund could not be processed. Please contact customer service for assistance."));
+        verify(notificationService).createSystemNotification(eq("user-002"), eq("The event has been canceled and your payment has been fully refunded."));
     }
 
     // ── OrderRefundedEvent ──────────────────────────────────────────────────

--- a/src/test/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListenerTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListenerTest.java
@@ -228,7 +228,7 @@ class NotificationEventListenerTest {
 
         verify(paymentGateway).refund(12345);
         verify(paymentGateway, never()).refund(-1);
-        verify(notificationService).createSystemNotification(eq(USER_ID), eq("The event has been canceled and your payment has been fully refunded."));
+        verify(notificationService).createSystemNotification(eq(USER_ID), eq("Event \"Rock Concert\" has been canceled and your payment of 50.00 for order ORD-001 has been fully refunded."));
         verify(notificationService).createSystemNotification(eq("user-002"), contains("Rock Concert"));
         verify(notificationService).createSystemNotification(eq("user-003"), contains("Rock Concert"));
     }
@@ -245,8 +245,8 @@ class NotificationEventListenerTest {
 
         verify(paymentGateway).refund(12345);
         verify(paymentGateway).refund(67890);
-        verify(notificationService).createSystemNotification(eq(USER_ID), eq("The event has been canceled, but your automatic refund could not be processed. Please contact customer service for assistance."));
-        verify(notificationService).createSystemNotification(eq("user-002"), eq("The event has been canceled and your payment has been fully refunded."));
+        verify(notificationService).createSystemNotification(eq(USER_ID), eq("Event \"Rock Concert\" has been canceled, but your automatic refund of 50.00 for order ORD-001 could not be processed. Please contact customer service for assistance."));
+        verify(notificationService).createSystemNotification(eq("user-002"), eq("Event \"Rock Concert\" has been canceled and your payment of 50.00 for order ORD-002 has been fully refunded."));
     }
 
     // ── OrderRefundedEvent ──────────────────────────────────────────────────

--- a/src/test/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListenerTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListenerTest.java
@@ -223,6 +223,7 @@ class NotificationEventListenerTest {
         HistoryOrderItem order2 = new HistoryOrderItem("ORD-002", "user-002", EVENT_ID, 1, 50.0, List.of(), new HashMap<>(), -1);
         HistoryOrderItem order3 = new HistoryOrderItem("ORD-003", "user-003", EVENT_ID, 1, 50.0, List.of(), new HashMap<>(), null);
         when(historyOrderRepo.findAllByEventId(EVENT_ID)).thenReturn(List.of(order1, order2, order3));
+        when(historyOrderRepo.save(any(HistoryOrderItem.class))).thenAnswer(i -> i.getArguments()[0]);
 
         listener.onEventCancelled(new EventCancelledEvent(EVENT_ID, "Rock Concert"));
 
@@ -240,6 +241,7 @@ class NotificationEventListenerTest {
         when(historyOrderRepo.findAllByEventId(EVENT_ID)).thenReturn(List.of(order1, order2));
 
         when(paymentGateway.refund(12345)).thenThrow(new RuntimeException("Gateway offline"));
+        when(historyOrderRepo.save(any(HistoryOrderItem.class))).thenAnswer(i -> i.getArguments()[0]);
 
         listener.onEventCancelled(new EventCancelledEvent(EVENT_ID, "Rock Concert"));
 
@@ -247,6 +249,26 @@ class NotificationEventListenerTest {
         verify(paymentGateway).refund(67890);
         verify(notificationService).createSystemNotification(eq(USER_ID), eq("Event \"Rock Concert\" has been canceled, but your automatic refund of 50.00 for order ORD-001 could not be processed. Please contact customer service for assistance."));
         verify(notificationService).createSystemNotification(eq("user-002"), eq("Event \"Rock Concert\" has been canceled and your payment of 50.00 for order ORD-002 has been fully refunded."));
+    }
+
+    @Test
+    void GivenCancellationRetriedAfterPartialFailure_WhenOnEventCancelled_ThenOnlyRefundRemainingOrders() {
+        // order1 was already refunded in a previous attempt (transactionId is -1)
+        HistoryOrderItem order1 = new HistoryOrderItem("ORD-001", USER_ID, EVENT_ID, 1, 50.0, List.of(), new HashMap<>(), -1);
+        // order2 is not yet refunded (has a valid transaction ID)
+        HistoryOrderItem order2 = new HistoryOrderItem("ORD-002", "user-002", EVENT_ID, 1, 50.0, List.of(), new HashMap<>(), 67890);
+        when(historyOrderRepo.findAllByEventId(EVENT_ID)).thenReturn(List.of(order1, order2));
+        when(historyOrderRepo.save(any(HistoryOrderItem.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        listener.onEventCancelled(new EventCancelledEvent(EVENT_ID, "Rock Concert"));
+
+        // Verify that paymentGateway.refund is only called for the remaining order (67890) and NOT for the already refunded one (-1)
+        verify(paymentGateway, never()).refund(-1);
+        verify(paymentGateway).refund(67890);
+        
+        // Verify appropriate notifications are sent
+        verify(notificationService).createSystemNotification(eq("user-002"), eq("Event \"Rock Concert\" has been canceled and your payment of 50.00 for order ORD-002 has been fully refunded."));
+        verify(notificationService).createSystemNotification(eq(USER_ID), eq("Event \"Rock Concert\" has been cancelled."));
     }
 
     // ── OrderRefundedEvent ──────────────────────────────────────────────────

--- a/src/test/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListenerTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/domain/notification/NotificationEventListenerTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.ticketpurchasingsystem.project.application.AuthenticationService;
 import com.ticketpurchasingsystem.project.application.INotificationService;
+import com.ticketpurchasingsystem.project.application.IPaymentGateway;
 import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderDTO;
 import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderEvents.CompletedOrderEvent;
 import com.ticketpurchasingsystem.project.domain.ActiveOrders.ActiveOrderEvents.OrderRefundedEvent;
@@ -37,6 +38,7 @@ class NotificationEventListenerTest {
     @Mock private AuthenticationService authenticationService;
     @Mock private IHistoryOrderRepo historyOrderRepo;
     @Mock private IEventRepo eventRepo;
+    @Mock private IPaymentGateway paymentGateway;
 
     private NotificationEventListener listener;
 
@@ -49,7 +51,7 @@ class NotificationEventListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new NotificationEventListener(notificationService, authenticationService, historyOrderRepo, eventRepo);
+        listener = new NotificationEventListener(notificationService, authenticationService, historyOrderRepo, eventRepo, paymentGateway);
     }
 
     // ── CompletedOrderEvent ─────────────────────────────────────────────────
@@ -213,6 +215,22 @@ class NotificationEventListenerTest {
         listener.onEventCancelled(new EventCancelledEvent(EVENT_ID, "Rock Concert"));
 
         verify(notificationService, never()).createSystemNotification(any(), any());
+    }
+
+    @Test
+    void GivenBuyersWithTransactionId_WhenOnEventCancelled_ThenRefundAndNotify() {
+        HistoryOrderItem order1 = new HistoryOrderItem("ORD-001", USER_ID, EVENT_ID, 1, 50.0, List.of(), new HashMap<>(), 12345);
+        HistoryOrderItem order2 = new HistoryOrderItem("ORD-002", "user-002", EVENT_ID, 1, 50.0, List.of(), new HashMap<>(), -1);
+        HistoryOrderItem order3 = new HistoryOrderItem("ORD-003", "user-003", EVENT_ID, 1, 50.0, List.of(), new HashMap<>(), null);
+        when(historyOrderRepo.findAllByEventId(EVENT_ID)).thenReturn(List.of(order1, order2, order3));
+
+        listener.onEventCancelled(new EventCancelledEvent(EVENT_ID, "Rock Concert"));
+
+        verify(paymentGateway).refund(12345);
+        verify(paymentGateway, never()).refund(-1);
+        verify(notificationService).createSystemNotification(eq(USER_ID), contains("Rock Concert"));
+        verify(notificationService).createSystemNotification(eq("user-002"), contains("Rock Concert"));
+        verify(notificationService).createSystemNotification(eq("user-003"), contains("Rock Concert"));
     }
 
     // ── OrderRefundedEvent ──────────────────────────────────────────────────


### PR DESCRIPTION
Triggers a refund rollback already built in payment_gateway where a refund event happens in the event of an error or cancellation after starting payment process. Had to add a nullable column called transacion_id to the history orders table in order to remember the specific order we need to refund. Doesn't make any problems it is completely nullable.
Added tests and all pass including browser tests 

Closes #321