### PR TITLE
345 reset order processing state on payment failure

### DIFF
--- a/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
@@ -304,8 +304,9 @@ public class ActiveOrderService implements IActiveOrderService {
             if(barcodesIssued == null){
                 throw new IllegalStateException("Barcode generation failed");
             }
-            activeOrderPublisher.publishCompletedOrder(orderDTO, amount, companyId, transactionId);
             activeOrderRepo.delete(orderId);
+            activeOrderPublisher.publishCompletedOrder(orderDTO, amount, companyId, transactionId);
+//            activeOrderRepo.delete(orderId);
             logger.info("Successfully completed order: " + orderId);
             return barcodesIssued;
         } catch (Exception e) {

--- a/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
@@ -69,11 +69,15 @@ public class ActiveOrderService implements IActiveOrderService {
             logger.warn("Cancel order failed: Order " + orderId + " is already being processed");
             throw new IllegalStateException("order is already being processed, cannot cancel");
         }
-
-        rollbackOrderReservations(sessionToken.getToken(), new ActiveOrderDTO(order));
-        activeOrderRepo.delete(orderId);
-        activeOrderPublisher.publishOrderCancelled(userId, orderId);
-        logger.info("Successfully cancelled active order: " + orderId + " for user: " + userId);
+        try {
+            rollbackOrderReservations(sessionToken.getToken(), new ActiveOrderDTO(order));
+            activeOrderRepo.delete(orderId);
+            activeOrderPublisher.publishOrderCancelled(userId, orderId);
+            logger.info("Successfully cancelled active order: " + orderId + " for user: " + userId);
+        }catch (Exception e){
+            activeOrderRepo.markAsNotProcessing(orderId);
+            logger.error("got error when trying to cancel order: "+ e.getMessage());
+        }
     }
 
     @Override
@@ -283,7 +287,8 @@ public class ActiveOrderService implements IActiveOrderService {
         if(transactionId == -1){
             logger.error("Payment failed for order: " + orderId + ". Rolling back and deleting order.");
             rollbackOrderReservations(sessionToken.getToken(), orderDTO);
-            activeOrderRepo.delete(orderId);
+//            activeOrderRepo.delete(orderId);
+            activeOrderRepo.markAsNotProcessing(orderId);
             throw new IllegalStateException("Payment failed");
         }
 
@@ -316,11 +321,17 @@ public class ActiveOrderService implements IActiveOrderService {
             } catch (Exception rollbackEx) {
                 logger.error("Failed to rollback reservations during rollback: " + rollbackEx.getMessage());
             }
-            try {
-                activeOrderRepo.delete(orderId);
-            } catch (Exception deleteEx) {
-                logger.error("Failed to delete active order during rollback: " + deleteEx.getMessage());
+            try{
+                activeOrderRepo.markAsNotProcessing(orderId);
             }
+            catch (Exception exception){
+                logger.error("Failed to mark order "+ orderId+" as not processing: "+ exception.getMessage());
+            }
+//            try {
+//                activeOrderRepo.delete(orderId);
+//            } catch (Exception deleteEx) {
+//                logger.error("Failed to delete active order during rollback: " + deleteEx.getMessage());
+//            }
             if (e instanceof RuntimeException) {
                 throw (RuntimeException) e;
             }

--- a/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
@@ -282,12 +282,18 @@ public class ActiveOrderService implements IActiveOrderService {
             logger.warn("Complete order failed: Order " + orderId + " is already being processed");
             throw new IllegalStateException("order is already being processed");
         }
-
-        int transactionId = payment(paymentGateway, sessionToken, paymentDetails);
-        if(transactionId == -1){
-            logger.error("Payment failed for order: " + orderId + ". Rolling back and deleting order.");
-            rollbackOrderReservations(sessionToken.getToken(), orderDTO);
+        int transactionId = -1;
+        try {
+            transactionId = payment(paymentGateway, sessionToken, paymentDetails);
+            if (transactionId == -1) {
+                logger.error("Payment failed for order: " + orderId + ". Rolling back and deleting order.");
+//                rollbackOrderReservations(sessionToken.getToken(), orderDTO);
 //            activeOrderRepo.delete(orderId);
+                activeOrderRepo.markAsNotProcessing(orderId);
+                throw new IllegalStateException("Payment failed");
+            }
+        }catch (Exception e){
+            logger.error("Payment failed for order: " + orderId + ". Rolling back and deleting order.");
             activeOrderRepo.markAsNotProcessing(orderId);
             throw new IllegalStateException("Payment failed");
         }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderItem.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderItem.java
@@ -175,4 +175,9 @@ public class ActiveOrderItem {
     public void setCreatedAt(Timestamp createdAt) {
         this.createdAt = createdAt;
     }
+    public boolean markAsNotProcessing() {
+        if (!processing) return false;
+        processing = false;
+        return true;
+    }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/IActiveOrderRepo.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/IActiveOrderRepo.java
@@ -12,5 +12,6 @@ public interface IActiveOrderRepo {
     ActiveOrderItem findByUserId(String userId);
     Optional<ActiveOrderItem> findByIdForUpdate(String orderId);
     boolean markAsProcessing(String orderId);
+    boolean markAsNotProcessing(String orderId);
     void deleteAll();
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/infrastructure/ActiveOrderMemRepo.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/infrastructure/ActiveOrderMemRepo.java
@@ -136,4 +136,6 @@ public class ActiveOrderMemRepo implements IActiveOrderRepo {
             lock.unlock();
         }
     }
+    @Override
+    public boolean markAs
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/infrastructure/ActiveOrderMemRepo.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/infrastructure/ActiveOrderMemRepo.java
@@ -137,5 +137,21 @@ public class ActiveOrderMemRepo implements IActiveOrderRepo {
         }
     }
     @Override
-    public boolean markAs
+    public boolean markAsNotProcessing(String orderId){
+        ReentrantLock lock = orderLocks.get(orderId);
+        if(lock == null){
+            throw new IllegalArgumentException("tried processing active order that was deleted or doesnt exist");
+        }
+        lock.lock();
+        try{
+            ActiveOrderItem existing = activeOrders.get(orderId);
+            if(existing == null){
+                throw new IllegalArgumentException("tried processing active order that was deleted or doesnt exist");
+            }
+            return existing.markAsNotProcessing();
+        }
+        finally {
+            lock.unlock();
+        }
+    }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/infrastructure/persistence/DBActiveOrderRepo.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/infrastructure/persistence/DBActiveOrderRepo.java
@@ -59,4 +59,17 @@ public interface DBActiveOrderRepo extends JpaRepository<ActiveOrderItem, String
         }
         return result;
     }
+    @Override
+    default boolean markAsNotProcessing(String orderId){
+        Optional<ActiveOrderItem> opt = findByIdForUpdate(orderId);
+        if (opt.isEmpty()) {
+            throw new IllegalArgumentException("Active order not found or already deleted: " + orderId);
+        }
+        ActiveOrderItem order = opt.get();
+        boolean result = order.markAsNotProcessing();
+        if (result) {
+            saveAndFlush(order);
+        }
+        return result;
+    }
 }

--- a/src/test/java/com/ticketpurchasingsystem/project/acceptance/activeorder/ActiveOrderAcceptanceTests.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/acceptance/activeorder/ActiveOrderAcceptanceTests.java
@@ -737,7 +737,7 @@ public class ActiveOrderAcceptanceTests {
     }
 
     @Test
-    public void GivenPaymentFailed_WhenCompleteOrder_ThenDeleteOrderAndThrowException() {
+    public void GivenPaymentFailed_WhenCompleteOrder_ThenThrowException() {
         try {
             String sessionToken = authenticationService.login(USER1_ID);
             SessionToken session = new SessionToken(sessionToken, 1000);
@@ -752,15 +752,37 @@ public class ActiveOrderAcceptanceTests {
             when(paymentGatewayMock.pay(any())).thenReturn(-1);
 
             assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId()));
-            assertTrue(activeOrderRepo.findById(order.getOrderId()).isEmpty());
-            assertEquals(eventService.checkSeatsReserved(sessionToken, order.getOrderId(), order.getEventId(), seatIds), seatIds);
+            //assertTrue(activeOrderRepo.findById(order.getOrderId()).isEmpty());
+            //assertEquals(eventService.checkSeatsReserved(sessionToken, order.getOrderId(), order.getEventId(), seatIds), seatIds);
+        } catch (Exception e) {
+            fail("got exception : " + e.getMessage());
+        }
+    }
+    @Test
+    public void GivenPaymentFailed_WhenCompleteOrder_ThenDontDeleteOrder() {
+        try {
+            String sessionToken = authenticationService.login(USER1_ID);
+            SessionToken session = new SessionToken(sessionToken, 1000);
+            ActiveOrderItem orderItem = activeOrderService.createPendingOrder(session, USER1_ID, testEvent.eventId());
+            if (orderItem == null) {
+                fail("couldnt create active order, should have worked");
+            }
+            activeOrderService.addSeatsToActiveOrder(session, orderItem.getOrderId(), seatIds);
+            ActiveOrderDTO order = activeOrderService.getActiveOrderInfo(session, orderItem.getOrderId());
+
+            double amountToPay = 100;
+            when(paymentGatewayMock.pay(any())).thenReturn(-1);
+
+            assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId()));
+            assertFalse(activeOrderRepo.findById(order.getOrderId()).isEmpty());
+            assertTrue(eventService.checkSeatsReserved(sessionToken, order.getOrderId(), order.getEventId(), seatIds).isEmpty());
         } catch (Exception e) {
             fail("got exception : " + e.getMessage());
         }
     }
 
     @Test
-    public void GivenBarcodeIssueFailed_WhenCompleteOrder_ThenDeleteOrderAndThrowException() {
+    public void GivenBarcodeIssueFailed_WhenCompleteOrder_ThenThrowException() {
         try {
             String sessionToken = authenticationService.login(USER1_ID);
             SessionToken session = new SessionToken(sessionToken, 1000);
@@ -776,7 +798,7 @@ public class ActiveOrderAcceptanceTests {
             when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(null);
 
             assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId()));
-            assertTrue(activeOrderRepo.findById(order.getOrderId()).isEmpty());
+            //assertTrue(activeOrderRepo.findById(order.getOrderId()).isEmpty());
             assertEquals(eventService.checkSeatsReserved(sessionToken, order.getOrderId(), order.getEventId(), seatIds), seatIds);
         } catch (Exception e) {
             fail("got exception : " + e.getMessage() + '\n' + java.util.Arrays.toString(e.getStackTrace()));

--- a/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
@@ -817,7 +817,7 @@ public class ActiveOrderServiceUnitTest {
 
     // Fix 6: GivenPaymentFails — remove isUsersOrder stub, use lenient for rollback guards
     @Test
-    void GivenPaymentFails_WhenCompleteOrder_ThenThrowIllegalStateExceptionAndRollback() {
+    void GivenPaymentFails_WhenCompleteOrder_ThenThrowIllegalStateException() {
         IPaymentGateway paymentGatewayMock = mock(IPaymentGateway.class);
         ActiveOrderItem validOrder = orderForUser(USER_ID);
         validOrder.setSeatIds(List.of("B-10", "B-11"));
@@ -839,15 +839,42 @@ public class ActiveOrderServiceUnitTest {
                 activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID)
         );
 
-        verify(activeOrderPublisherMock, times(1)).publishReleaseSeats(VALID_TOKEN, ORDER_ID, EVENT_ID, List.of("B-10", "B-11"));
-        verify(activeOrderPublisherMock, times(1)).publishReleaseStandingArea(VALID_TOKEN, EVENT_ID, "VIP-1", 2);
-        verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
+        //verify(activeOrderPublisherMock, times(1)).publishReleaseSeats(VALID_TOKEN, ORDER_ID, EVENT_ID, List.of("B-10", "B-11"));
+        //verify(activeOrderPublisherMock, times(1)).publishReleaseStandingArea(VALID_TOKEN, EVENT_ID, "VIP-1", 2);
+        //verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
         verify(activeOrderPublisherMock, never()).publishCompletedOrder(any(), anyDouble(), anyInt(), anyInt());
+    }
+    @Test
+    void GivenPaymentFails_WhenCompleteOrder_ThenDontDeleteOrder() {
+        IPaymentGateway paymentGatewayMock = mock(IPaymentGateway.class);
+        ActiveOrderItem validOrder = orderForUser(USER_ID);
+        validOrder.setSeatIds(List.of("B-10", "B-11"));
+
+        HashMap<String, Integer> standingArea = new HashMap<>();
+        standingArea.put("VIP-1", 2);
+        validOrder.setStandingAreaQuantities(standingArea);
+
+        when(authenticationServiceMock.validate(VALID_TOKEN)).thenReturn(true);
+        when(activeOrderRepoMock.findByIdForUpdate(ORDER_ID)).thenReturn(Optional.of(validOrder));
+        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        when(activeOrderPublisherMock.publishGetCompanyId(anyString())).thenReturn(COMPANY_ID);
+        when(activeOrderRepoMock.markAsProcessing(ORDER_ID)).thenReturn(true);
+        when(paymentGatewayMock.pay(any())).thenReturn(-1);
+        lenient().when(activeOrderHandlerMock.canReleaseSeats(validOrder.getSeatIds())).thenReturn(true);
+        lenient().when(activeOrderHandlerMock.canReleaseStanding(validOrder.getStandingAreaQuantities())).thenReturn(true);
+
+        assertThrows(Exception.class, () ->
+                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID)
+        );
+
+        verify(activeOrderPublisherMock, times(0)).publishReleaseSeats(VALID_TOKEN, ORDER_ID, EVENT_ID, List.of("B-10", "B-11"));
+        verify(activeOrderPublisherMock, times(0)).publishReleaseStandingArea(VALID_TOKEN, EVENT_ID, "VIP-1", 2);
+        verify(activeOrderRepoMock, times(0)).delete(ORDER_ID);
     }
 
 
     @Test
-    void GivenBarcodeGenerationFails_WhenCompleteOrder_ThenThrowIllegalStateExceptionAndRollback() {
+    void GivenBarcodeGenerationFails_WhenCompleteOrder_ThenThrowExceptionAndRollback() {
         IPaymentGateway paymentGatewayMock = mock(IPaymentGateway.class);
         ActiveOrderItem validOrder = orderForUser(USER_ID);
         validOrder.setSeatIds(List.of("C-1"));
@@ -869,7 +896,7 @@ public class ActiveOrderServiceUnitTest {
 
         verify(paymentGatewayMock, times(1)).refund(100);
         verify(activeOrderPublisherMock, times(1)).publishReleaseSeats(VALID_TOKEN, ORDER_ID, EVENT_ID, List.of("C-1"));
-        verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
+        //verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
         verify(activeOrderPublisherMock, never()).publishCompletedOrder(any(), anyDouble(), anyInt(), anyInt());
     }
 


### PR DESCRIPTION
_**- Changed the implementation of completeOrder() in ActiveOrderService:**_
- - made it so the activeOrder is deleted and returns all its tickets only if the order is succesfully paid for and got the barcodes of the tickets
- - made it so the "processing" field of the activeOrder is changed back to "false" if an error happens mid checkout

**_- changed the implementation of cancelOrder() in ActiveOrderService:_**
- - made it so the "processing" field of the activeOrder is changed back to "false" if an error happens mid cancellation

**_- in Tests:_**
- - changed tests that checked if the order is deleted when we get an error during checkout, and renamed them accordingly
- - made new tests that check that when an error happens with the payment during checkout, the order stays intact and is not deleted