### PR TITLE
354 refactor methods in activeorderservice

### DIFF
--- a/frontend/src/api/activeOrderApi.ts
+++ b/frontend/src/api/activeOrderApi.ts
@@ -32,6 +32,7 @@ export interface CheckoutRequestDTO {
     expirationDate: string;
     cvv: string;
     id: string;
+    age: number|null
 }
 
 export interface CheckoutResponseDTO {
@@ -208,7 +209,8 @@ export const activeOrderApi = {
             year: year || '',
             holder: data.cardHolderName,
             cvv: data.cvv,
-            id: data.id
+            id: data.id,
+            age: data.age
         };
 
         const response = await fetch(`${BASE_URL}/${orderId}/checkout`, {

--- a/frontend/src/pages/orders/CheckoutPage.tsx
+++ b/frontend/src/pages/orders/CheckoutPage.tsx
@@ -277,7 +277,7 @@ export default function CheckoutPage() {
   };
 
   // ─── Main Payment Authorization Execution ─────────────────────────────────
-  const handlePayment = async () => {
+  const handlePayment = async (age: number | null = null) => {
     try {
       setProcessState('processing');
       const token = localStorage.getItem('token') || localStorage.getItem('authToken') || '';
@@ -291,6 +291,7 @@ export default function CheckoutPage() {
         expirationDate: expiryDate.replace(/\s/g, ''),
         cvv: cvv.trim(),
         id: cardholderId.trim(),
+        age:age
       };
 
       const checkoutResult = await activeOrderApi.checkout(token, order.orderId, checkoutPayload);
@@ -327,7 +328,7 @@ export default function CheckoutPage() {
     }
 
     // If the policy passes validation, call the payment routine
-    await handlePayment();
+    await handlePayment(age);
   }
 
   const handleConfirmAge = () => {

--- a/src/main/java/com/ticketpurchasingsystem/project/Controllers/ActiveOrderController.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/Controllers/ActiveOrderController.java
@@ -192,7 +192,7 @@ public class ActiveOrderController {
         SessionToken sessionToken = toSessionToken(authHeader);
         try {
             List<BarcodeDTO> barcodes = activeOrderService.completeOrder(
-                    paymentGateway, sessionToken, body.toPaymentDetails(), orderId);
+                    paymentGateway, sessionToken, body.toPaymentDetails(), orderId, body.getAge());
             List<String> barcodeValues = barcodes.stream()
                     .map(BarcodeDTO::getBarcodeValue)
                     .collect(Collectors.toList());

--- a/src/main/java/com/ticketpurchasingsystem/project/Controllers/apidto/CheckoutRequestDTO.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/Controllers/apidto/CheckoutRequestDTO.java
@@ -11,6 +11,7 @@ public class CheckoutRequestDTO {
     private String holder;
     private String cvv;
     private String id;
+    private Integer age;
 
     public PaymentDetails toPaymentDetails() {
         return new PaymentDetails(amount, currency, cardNumber, month, year, holder, cvv, id);
@@ -39,4 +40,7 @@ public class CheckoutRequestDTO {
 
     public String getId()          { return id; }
     public void setId(String id)   { this.id = id; }
+
+    public Integer getAge(){ return age; }
+    public void setAge(Integer age){ this.age = age; }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
@@ -249,10 +249,14 @@ public class ActiveOrderService implements IActiveOrderService {
         }
     }
 
+
+    /**
+    call with age = null if age is irrelevant
+     */
     @Override
     @Transactional(noRollbackFor = RuntimeException.class)
     public List<BarcodeDTO> completeOrder(IPaymentGateway paymentGateway, SessionToken sessionToken,
-            PaymentDetails paymentDetails, String orderId) {
+            PaymentDetails paymentDetails, String orderId, Integer age) {
         double amount = paymentDetails.getAmount();
         logger.info("Attempting to complete order: " + orderId + " with amount: " + amount);
         validateSession(sessionToken, "Session validation failed while completing order: " + orderId,
@@ -286,7 +290,6 @@ public class ActiveOrderService implements IActiveOrderService {
             throw new RuntimeException("couldn't retrieve company information for this event");
         }
 
-        int age = getUserAge(sessionToken);
         boolean upToPolicy = activeOrderPublisher.publishIsUpToPolicy(orderDTO, age);
         if (!upToPolicy) {
             logger.error("Complete order failed: Order " + orderId + " violates purchase policies");
@@ -515,9 +518,5 @@ public class ActiveOrderService implements IActiveOrderService {
 
     private boolean isValidEventID(String eventId) {
         return activeOrderPublisher.publishIsValidEventIDEvent(eventId);
-    }
-
-    private int getUserAge(SessionToken sessionToken) {
-        return 20;
     }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/ActiveOrderService.java
@@ -166,7 +166,7 @@ public class ActiveOrderService implements IActiveOrderService {
         List<String> previewSeats = new ArrayList<>(previewDTO.getSeatIds());
         previewSeats.addAll(seatsToReserve);
         previewDTO.setSeatIds(previewSeats);
-        if (!activeOrderPublisher.publishIsUpToPolicy(previewDTO, getUserAge(sessionToken))) {
+        if (!activeOrderPublisher.publishIsUpToPolicy(previewDTO, null)) {
             logger.error("Add seats failed: Adding seats would exceed purchase policy limit for order: " + orderId);
             throw new IllegalStateException("Cannot add tickets: purchase policy limit would be exceeded");
         }
@@ -217,7 +217,7 @@ public class ActiveOrderService implements IActiveOrderService {
         HashMap<String, Integer> previewStanding = previewStandingDTO.getStandingAreaQuantities();
         previewStanding.merge(areaId, quantity, Integer::sum);
         previewStandingDTO.setStandingAreaQuantities(previewStanding);
-        if (!activeOrderPublisher.publishIsUpToPolicy(previewStandingDTO, getUserAge(sessionToken))) {
+        if (!activeOrderPublisher.publishIsUpToPolicy(previewStandingDTO, null)) {
             logger.error("Add standing area failed: Adding tickets would exceed purchase policy limit for order: "
                     + orderId);
             throw new IllegalStateException("Cannot add tickets: purchase policy limit would be exceeded");
@@ -362,7 +362,7 @@ public class ActiveOrderService implements IActiveOrderService {
         }
         checkIfExpiredAndThrowException(sessionToken.getToken(), order);
 
-        if (!activeOrderPublisher.publishIsUpToPolicy(newOrderDTO, getUserAge(sessionToken))) {
+        if (!activeOrderPublisher.publishIsUpToPolicy(newOrderDTO, null)) {
             logger.error("Update order failed: Order violates purchase policy for order: " + newOrderDTO.getOrderId());
             throw new IllegalStateException(
                     "Cannot reserve tickets: you have already purchased the maximum allowed tickets for this event");

--- a/src/main/java/com/ticketpurchasingsystem/project/application/IActiveOrderService.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/application/IActiveOrderService.java
@@ -15,6 +15,6 @@ public interface  IActiveOrderService {
     public void addStandingAreaToActiveOrder(SessionToken sessionToken, String orderId, String areaId, int quantity);
     public void updateActiveOrder(SessionToken sessionToken, ActiveOrderDTO order);
     public boolean saveOrder(ActiveOrderItem order);
-    public List<BarcodeDTO> completeOrder(IPaymentGateway paymentGateway, SessionToken sessionToken, PaymentDetails paymentDetails, String orderId);
+    public List<BarcodeDTO> completeOrder(IPaymentGateway paymentGateway, SessionToken sessionToken, PaymentDetails paymentDetails, String orderId, Integer age);
     public ActiveOrderDTO getActiveOrderByUserId(SessionToken sessionToken, String userId) throws Exception;
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderEvents/IsUpToPolicyEvent.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderEvents/IsUpToPolicyEvent.java
@@ -9,8 +9,8 @@ import java.util.List;
 public class IsUpToPolicyEvent extends ApplicationEvent {
     private ActiveOrderDTO order;
     private Boolean result;
-    private int age;
-    public IsUpToPolicyEvent(Object source, ActiveOrderDTO order, int age){
+    private Integer age= null;
+    public IsUpToPolicyEvent(Object source, ActiveOrderDTO order, Integer age){
         super(source);
         this.order = order;
         this.result = null;
@@ -49,7 +49,7 @@ public class IsUpToPolicyEvent extends ApplicationEvent {
         return total;
     }
 
-    public int getAge()
+    public Integer getAge()
     {
        return age;
     }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderPublisher.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderPublisher.java
@@ -50,7 +50,7 @@ public class ActiveOrderPublisher {
     //     eventPublisher.publishEvent(event);
     // }
 
-    public boolean publishIsUpToPolicy(ActiveOrderDTO order, int age){
+    public boolean publishIsUpToPolicy(ActiveOrderDTO order, Integer age){
         IsUpToPolicyEvent event = new IsUpToPolicyEvent(this,order, age);
         eventPublisher.publishEvent(event);
         return event.getResult();

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/EventAggregateListener.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/EventAggregateListener.java
@@ -91,13 +91,18 @@ public class EventAggregateListener {
             }
         }
 
-        PurchaseContext context = new PurchaseContext(
-                event.getTotalTickets(),
-                event.getAge(),
-                alreadyPurchased);
-
-        boolean isValid = policy.validate(context);
-        event.setResult(isValid);
+            PurchaseContext context = new PurchaseContext(
+                    event.getTotalTickets(),
+                    event.getAge(),
+                    alreadyPurchased);
+        boolean isValid;
+        if(event.getAge() != null) {
+            isValid = policy.validate(context);
+        }
+        else {
+            isValid = policy.validateTicketPolicy(context);
+        }
+            event.setResult(isValid);
     }
     @EventListener
     public void onIsValidEventIDEvent(IsValidEventIDEvent event){

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/EventAggregateListener.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/EventAggregateListener.java
@@ -91,15 +91,20 @@ public class EventAggregateListener {
             }
         }
 
-            PurchaseContext context = new PurchaseContext(
+            PurchaseContext context;
+        boolean isValid;
+        if(event.getAge() != null) {
+            context = new PurchaseContext(
                     event.getTotalTickets(),
                     event.getAge(),
                     alreadyPurchased);
-        boolean isValid;
-        if(event.getAge() != null) {
             isValid = policy.validate(context);
         }
         else {
+            context = new PurchaseContext(
+                    event.getTotalTickets(),
+                    0,
+                    alreadyPurchased);
             isValid = policy.validateTicketPolicy(context);
         }
             event.setResult(isValid);

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/AndRule.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/AndRule.java
@@ -17,4 +17,7 @@ public class AndRule implements IPurchaseRule{
     public IPurchaseRule getComponent2() {
         return component2;
     }
+    public boolean validateTicketPolicy(PurchaseContext context){
+        return component1.validateTicketPolicy(context) && component2.validateTicketPolicy(context);
+    }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/EventPurchasePolicy.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/EventPurchasePolicy.java
@@ -128,4 +128,11 @@ public class EventPurchasePolicy implements IPurchaseRule {
                 isAgeAndQuantityOr != null && isAgeAndQuantityOr
         );
     }
+
+    public boolean validateTicketPolicy(PurchaseContext context){
+        for (IPurchaseRule rule : rules) {
+            if (!rule.validateTicketPolicy(context)) { return false; }
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/IPurchaseRule.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/IPurchaseRule.java
@@ -2,4 +2,5 @@ package com.ticketpurchasingsystem.project.domain.event.Purchase_Policy;
 
 public interface IPurchaseRule {
     boolean validate(PurchaseContext context);
+    boolean validateTicketPolicy(PurchaseContext context);
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/MaxAgeRule.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/MaxAgeRule.java
@@ -15,4 +15,7 @@ public class MaxAgeRule implements IPurchaseRule {
     public int getMaxAge() {
         return maxAge;
     }
+    public boolean validateTicketPolicy(PurchaseContext context){
+        return true;
+    }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/MaxTicketsRule.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/MaxTicketsRule.java
@@ -15,4 +15,7 @@ public class MaxTicketsRule implements IPurchaseRule {
     public int getLimit() {
         return limit;
     }
+    public boolean validateTicketPolicy(PurchaseContext context){
+        return validate(context);
+    }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/MinAgeRule.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/MinAgeRule.java
@@ -14,4 +14,8 @@ public class MinAgeRule implements IPurchaseRule {
     public int getMinAge() {
         return minAge;
     }
+
+    public boolean validateTicketPolicy(PurchaseContext context){
+        return true;
+    }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/MinTicketsRule.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/MinTicketsRule.java
@@ -14,4 +14,7 @@ public class MinTicketsRule implements IPurchaseRule {
     public int getLimit() {
         return limit;
     }
+    public boolean validateTicketPolicy(PurchaseContext context){
+        return validate(context);
+    }
 }

--- a/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/OrRule.java
+++ b/src/main/java/com/ticketpurchasingsystem/project/domain/event/Purchase_Policy/OrRule.java
@@ -19,4 +19,7 @@ public class OrRule implements IPurchaseRule {
     public IPurchaseRule getComponent2() {
         return component2;
     }
+    public boolean validateTicketPolicy(PurchaseContext context){
+        return component1.validateTicketPolicy(context) || component2.validateTicketPolicy(context);
+    }
 }

--- a/src/test/java/com/ticketpurchasingsystem/project/acceptance/activeorder/ActiveOrderAcceptanceTests.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/acceptance/activeorder/ActiveOrderAcceptanceTests.java
@@ -669,7 +669,7 @@ public class ActiveOrderAcceptanceTests {
             when(paymentGatewayMock.pay(any())).thenReturn(50000);
             when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(new BarcodeDTO("barcode1")));
 
-            assertDoesNotThrow(() -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId()));
+            assertDoesNotThrow(() -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId(), null));
             assertThrows(Exception.class, () -> activeOrderService.getActiveOrderInfo(session, order.getOrderId()));
             assertTrue(activeOrderRepo.findById(order.getOrderId()).isEmpty());
 
@@ -696,7 +696,7 @@ public class ActiveOrderAcceptanceTests {
             when(paymentGatewayMock.pay(any())).thenReturn(50000);
             when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(new BarcodeDTO("barcode1")));
 
-            assertDoesNotThrow(() -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId()));
+            assertDoesNotThrow(() -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId(),null));
             HistoryOrderItem historyOrderItem = assertDoesNotThrow(() -> historyOrderRepo.findByOrderId(order.getOrderId()));
             assertNotNull(historyOrderItem);
             HistoryOrderDTO historyOrderDTO = historyOrderItem.makeDTO();
@@ -728,7 +728,7 @@ public class ActiveOrderAcceptanceTests {
             double amountToPay = 100;
             order.setCreatedAt(java.sql.Timestamp.valueOf("1977-10-10 00:00:00"));
             activeOrderRepo.update(new ActiveOrderItem(order));
-            assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId()));
+            assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId(), null));
             assertTrue(activeOrderRepo.findById(order.getOrderId()).isEmpty());
             assertEquals(eventService.checkSeatsReserved(sessionToken, order.getOrderId(), order.getEventId(), seatIds), seatIds);
         } catch (Exception e) {
@@ -751,7 +751,7 @@ public class ActiveOrderAcceptanceTests {
             double amountToPay = 100;
             when(paymentGatewayMock.pay(any())).thenReturn(-1);
 
-            assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId()));
+            assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId(), null));
             assertTrue(activeOrderRepo.findById(order.getOrderId()).isEmpty());
             assertEquals(eventService.checkSeatsReserved(sessionToken, order.getOrderId(), order.getEventId(), seatIds), seatIds);
         } catch (Exception e) {
@@ -775,7 +775,7 @@ public class ActiveOrderAcceptanceTests {
             when(paymentGatewayMock.pay(any())).thenReturn(50000);
             when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(null);
 
-            assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId()));
+            assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId(),null));
             assertTrue(activeOrderRepo.findById(order.getOrderId()).isEmpty());
             assertEquals(eventService.checkSeatsReserved(sessionToken, order.getOrderId(), order.getEventId(), seatIds), seatIds);
         } catch (Exception e) {
@@ -799,7 +799,7 @@ public class ActiveOrderAcceptanceTests {
             PurchasePolicyDTO newPolicy = new PurchasePolicyDTO(10, eventCapacity, false, 0, 60, true, false);
             eventService.editEventPurchasePolicy(sessionToken, testEvent.eventId(), newPolicy);
 
-            assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId()));
+            assertThrows(Exception.class, () -> activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(amountToPay), order.getOrderId(),null));
         } catch (Exception e) {
             fail("got exception : " + e.getMessage());
         }
@@ -884,7 +884,7 @@ public class ActiveOrderAcceptanceTests {
             new Thread(() -> {
                 try {
                     startLatch.await();
-                    activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(100.0), liveOrderId);
+                    activeOrderService.completeOrder(paymentGatewayMock, session, paymentDetailsFor(100.0), liveOrderId, null);
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();

--- a/src/test/java/com/ticketpurchasingsystem/project/acceptance/concurrency/ConcurrencyIntegrationTests.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/acceptance/concurrency/ConcurrencyIntegrationTests.java
@@ -230,7 +230,7 @@ public class ConcurrencyIntegrationTests {
         executor.submit(() -> {
             try {
                 startLatch.await();
-                activeOrderService.completeOrder(paymentGatewayMock, new SessionToken(sessionToken, 1000), new PaymentDetails(100.0, "USD", "4111111111111111", "12", "2028", "Test User", "123", "ID-001"), order.getOrderId());
+                activeOrderService.completeOrder(paymentGatewayMock, new SessionToken(sessionToken, 1000), new PaymentDetails(100.0, "USD", "4111111111111111", "12", "2028", "Test User", "123", "ID-001"), order.getOrderId(), null);
                 successCount.incrementAndGet();
             } catch (Exception e) {
                 failureCount.incrementAndGet();
@@ -243,7 +243,7 @@ public class ConcurrencyIntegrationTests {
         executor.submit(() -> {
             try {
                 startLatch.await();
-                activeOrderService.completeOrder(paymentGatewayMock, new SessionToken(sessionToken, 1000), new PaymentDetails(100.0, "USD", "4111111111111111", "12", "2028", "Test User", "123", "ID-001"), order.getOrderId());
+                activeOrderService.completeOrder(paymentGatewayMock, new SessionToken(sessionToken, 1000), new PaymentDetails(100.0, "USD", "4111111111111111", "12", "2028", "Test User", "123", "ID-001"), order.getOrderId(), null);
                 successCount.incrementAndGet();
             } catch (Exception e) {
                 failureCount.incrementAndGet();

--- a/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
@@ -81,7 +81,7 @@ public class ActiveOrderServiceUnitTest {
     @BeforeEach
     void setUp() {
         lenient().when(authenticationServiceMock.getUser(VALID_TOKEN)).thenReturn(USER_ID);
-        lenient().when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        lenient().when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
     }
 
     //------------------------------------------------------------------------------------------------------------------
@@ -726,7 +726,7 @@ public class ActiveOrderServiceUnitTest {
         when(authenticationServiceMock.validate(VALID_TOKEN)).thenReturn(true);
         // validateOrderOwnership: default void mock passes — no stub needed
         when(activeOrderRepoMock.findByIdForUpdate(ORDER_ID)).thenReturn(Optional.of(validOrder));
-        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
         when(activeOrderPublisherMock.publishGetCompanyId(anyString())).thenReturn(COMPANY_ID);
         when(activeOrderRepoMock.markAsProcessing(ORDER_ID)).thenReturn(true);
         when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(new BarcodeDTO("barcode")));
@@ -747,7 +747,7 @@ public class ActiveOrderServiceUnitTest {
         when(authenticationServiceMock.validate(VALID_TOKEN)).thenReturn(true);
         // validateOrderOwnership: default void mock passes — no stub needed
         when(activeOrderRepoMock.findByIdForUpdate(ORDER_ID)).thenReturn(Optional.of(validOrder));
-        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
         when(activeOrderPublisherMock.publishGetCompanyId(anyString())).thenReturn(COMPANY_ID);
         when(activeOrderRepoMock.markAsProcessing(ORDER_ID)).thenReturn(true);
         when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(new BarcodeDTO("barcode")));
@@ -828,7 +828,7 @@ public class ActiveOrderServiceUnitTest {
 
         when(authenticationServiceMock.validate(VALID_TOKEN)).thenReturn(true);
         when(activeOrderRepoMock.findByIdForUpdate(ORDER_ID)).thenReturn(Optional.of(validOrder));
-        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
         when(activeOrderPublisherMock.publishGetCompanyId(anyString())).thenReturn(COMPANY_ID);
         when(activeOrderRepoMock.markAsProcessing(ORDER_ID)).thenReturn(true);
         when(paymentGatewayMock.pay(any())).thenReturn(-1);
@@ -855,7 +855,7 @@ public class ActiveOrderServiceUnitTest {
         when(authenticationServiceMock.validate(VALID_TOKEN)).thenReturn(true);
         // validateOrderOwnership: default void mock passes — no stub needed
         when(activeOrderRepoMock.findByIdForUpdate(ORDER_ID)).thenReturn(Optional.of(validOrder));
-        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
         when(activeOrderPublisherMock.publishGetCompanyId(anyString())).thenReturn(COMPANY_ID);
         when(activeOrderRepoMock.markAsProcessing(ORDER_ID)).thenReturn(true);
         when(paymentGatewayMock.pay(any())).thenReturn(100);
@@ -881,7 +881,7 @@ public class ActiveOrderServiceUnitTest {
 
         when(authenticationServiceMock.validate(VALID_TOKEN)).thenReturn(true);
         when(activeOrderRepoMock.findByIdForUpdate(ORDER_ID)).thenReturn(Optional.of(validOrder));
-        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
         when(activeOrderPublisherMock.publishGetCompanyId(anyString())).thenReturn(COMPANY_ID);
         when(activeOrderRepoMock.markAsProcessing(ORDER_ID)).thenReturn(true);
         when(paymentGatewayMock.pay(any())).thenReturn(200);
@@ -922,7 +922,7 @@ public class ActiveOrderServiceUnitTest {
         when(authenticationServiceMock.getUser("valid-token")).thenReturn("userA");
         // validateOrderOwnership: default void mock passes — no stub needed
         lenient().when(activeOrderPublisherMock.publishIsValidEventIDEvent(anyString())).thenReturn(true);
-        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
         when(activeOrderPublisherMock.publishGetCompanyId(anyString())).thenReturn(COMPANY_ID);
         when(paymentGatewayMock.pay(any())).thenReturn(50000);
         when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(mock(BarcodeDTO.class)));
@@ -970,7 +970,7 @@ public class ActiveOrderServiceUnitTest {
 
         when(authenticationServiceMock.validate("valid-token")).thenReturn(true);
         lenient().when(activeOrderPublisherMock.publishIsValidEventIDEvent(anyString())).thenReturn(true);
-        lenient().when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        lenient().when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
         lenient().when(paymentGatewayMock.pay(any())).thenReturn(50000);
         lenient().when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(mock(BarcodeDTO.class)));
         lenient().when(activeOrderHandlerMock.isUsersOrder(anyString(), any())).thenReturn(true);
@@ -1027,7 +1027,7 @@ public class ActiveOrderServiceUnitTest {
         lenient().when(authenticationServiceMock.getUser(anyString())).thenAnswer(inv -> inv.getArgument(0));
         lenient().when(activeOrderHandlerMock.isUsersOrder(any(), any())).thenReturn(true);
         lenient().when(activeOrderPublisherMock.publishIsValidEventIDEvent(anyString())).thenReturn(true);
-        lenient().when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        lenient().when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
         lenient().when(activeOrderPublisherMock.publishGetCompanyId(anyString())).thenReturn(COMPANY_ID);
         lenient().when(paymentGatewayMock.pay(any())).thenReturn(50000);
         lenient().when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(mock(BarcodeDTO.class)));
@@ -1285,7 +1285,7 @@ public class ActiveOrderServiceUnitTest {
 
         verify(activeOrderHandlerMock, times(1)).removeSeatsFromActiveOrder(order, unreservedSeats);
         verify(activeOrderRepoMock, times(1)).update(updatedOrderMock);
-        verify(activeOrderPublisherMock, never()).publishIsUpToPolicy(any(), anyInt());
+        verify(activeOrderPublisherMock, never()).publishIsUpToPolicy(any(), any());
         verify(activeOrderRepoMock, never()).markAsProcessing(anyString());
         verify(barcodeGatewayMock, never()).issueBarcodes(any());
         verifyNoInteractions(paymentGatewayMock);

--- a/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
@@ -732,7 +732,7 @@ public class ActiveOrderServiceUnitTest {
         when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(new BarcodeDTO("barcode")));
         when(paymentGatewayMock.pay(any())).thenReturn(50000);
 
-        List<BarcodeDTO> result = activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID);
+        List<BarcodeDTO> result = activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID, null);
 
         assertNotNull(result);
         verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
@@ -753,7 +753,7 @@ public class ActiveOrderServiceUnitTest {
         when(barcodeGatewayMock.issueBarcodes(any())).thenReturn(List.of(new BarcodeDTO("barcode")));
         when(paymentGatewayMock.pay(any())).thenReturn(50000);
 
-        List<BarcodeDTO> result = activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID);
+        List<BarcodeDTO> result = activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID, null);
 
         assertNotNull(result);
         verify(activeOrderRepoMock, times(1)).delete(ORDER_ID);
@@ -768,7 +768,7 @@ public class ActiveOrderServiceUnitTest {
 
         // Act & Assert
         assertThrows(RuntimeException.class, () ->
-                activeOrderService.completeOrder(paymentGatewayMock, INVALID_SESSION, validPaymentDetails(), ORDER_ID)
+                activeOrderService.completeOrder(paymentGatewayMock, INVALID_SESSION, validPaymentDetails(), ORDER_ID, null)
         );
         verify(activeOrderRepoMock, never()).markAsProcessing(anyString());
         verify(activeOrderRepoMock, never()).delete(anyString());
@@ -783,7 +783,7 @@ public class ActiveOrderServiceUnitTest {
 
         // Act & Assert
         assertThrows(IllegalArgumentException.class, () ->
-                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID)
+                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID, null)
         );
         verify(activeOrderRepoMock, never()).delete(anyString());
     }
@@ -807,7 +807,7 @@ public class ActiveOrderServiceUnitTest {
         when(activeOrderHandlerMock.canReleaseStanding(any())).thenReturn(true);
 
         assertThrows(Exception.class, () ->
-                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID)
+                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID, null)
         );
 
         verify(activeOrderPublisherMock, times(1)).publishReleaseSeats(VALID_TOKEN, ORDER_ID, EVENT_ID, List.of("A-1", "A-2"));
@@ -836,7 +836,7 @@ public class ActiveOrderServiceUnitTest {
         lenient().when(activeOrderHandlerMock.canReleaseStanding(validOrder.getStandingAreaQuantities())).thenReturn(true);
 
         assertThrows(Exception.class, () ->
-                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID)
+                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID, null)
         );
 
         verify(activeOrderPublisherMock, times(1)).publishReleaseSeats(VALID_TOKEN, ORDER_ID, EVENT_ID, List.of("B-10", "B-11"));
@@ -864,7 +864,7 @@ public class ActiveOrderServiceUnitTest {
         lenient().when(activeOrderHandlerMock.canReleaseStanding(validOrder.getStandingAreaQuantities())).thenReturn(true);
 
         assertThrows(Exception.class, () ->
-                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID)
+                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID, null)
         );
 
         verify(paymentGatewayMock, times(1)).refund(100);
@@ -897,7 +897,7 @@ public class ActiveOrderServiceUnitTest {
         lenient().when(activeOrderHandlerMock.canReleaseStanding(validOrder.getStandingAreaQuantities())).thenReturn(true);
 
         assertThrows(Exception.class, () ->
-                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID)
+                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID, null)
         );
 
         verify(paymentGatewayMock, times(1)).refund(200);
@@ -938,7 +938,7 @@ public class ActiveOrderServiceUnitTest {
         Runnable completionTask = () -> {
             try {
                 startLatch.await();
-                service.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), liveOrderId);
+                service.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), liveOrderId, null);
                 successCount.incrementAndGet();
             } catch (Exception e) {
                 failCount.incrementAndGet();
@@ -987,7 +987,7 @@ public class ActiveOrderServiceUnitTest {
         new Thread(() -> {
             try {
                 startLatch.await();
-                service.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), liveOrderId);
+                service.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), liveOrderId, null);
                 successCount.incrementAndGet();
             } catch (Exception e) { failCount.incrementAndGet(); }
             finally { doneLatch.countDown(); }
@@ -1050,7 +1050,7 @@ public class ActiveOrderServiceUnitTest {
             executor.submit(() -> {
                 try {
                     startLatch.await();
-                    service.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), liveOrderId);
+                    service.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), liveOrderId, null);
                     successCount.incrementAndGet();
                 } catch (Exception e) { errors.add(e); }
                 finally { doneLatch.countDown(); }
@@ -1256,7 +1256,7 @@ public class ActiveOrderServiceUnitTest {
         IPaymentGateway paymentGateway = mock(IPaymentGateway.class);
 
         Exception exception = assertThrows(IllegalArgumentException.class, () ->
-                activeOrderService.completeOrder(paymentGateway, sessionTokenUserA, validPaymentDetails(), "order1")
+                activeOrderService.completeOrder(paymentGateway, sessionTokenUserA, validPaymentDetails(), "order1", null)
         );
 
         assertEquals("Unauthorized: Order does not belong to the current user", exception.getMessage());
@@ -1280,7 +1280,7 @@ public class ActiveOrderServiceUnitTest {
         when(activeOrderHandlerMock.removeSeatsFromActiveOrder(order, unreservedSeats)).thenReturn(updatedOrderMock);
 
         assertThrows(IllegalStateException.class, () ->
-                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID)
+                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID, null)
         );
 
         verify(activeOrderHandlerMock, times(1)).removeSeatsFromActiveOrder(order, unreservedSeats);

--- a/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
+++ b/src/test/java/com/ticketpurchasingsystem/project/domain/ActiveOrders/ActiveOrderServiceUnitTest.java
@@ -856,7 +856,7 @@ public class ActiveOrderServiceUnitTest {
 
         when(authenticationServiceMock.validate(VALID_TOKEN)).thenReturn(true);
         when(activeOrderRepoMock.findByIdForUpdate(ORDER_ID)).thenReturn(Optional.of(validOrder));
-        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), anyInt())).thenReturn(true);
+        when(activeOrderPublisherMock.publishIsUpToPolicy(any(), any())).thenReturn(true);
         when(activeOrderPublisherMock.publishGetCompanyId(anyString())).thenReturn(COMPANY_ID);
         when(activeOrderRepoMock.markAsProcessing(ORDER_ID)).thenReturn(true);
         when(paymentGatewayMock.pay(any())).thenReturn(-1);
@@ -864,7 +864,7 @@ public class ActiveOrderServiceUnitTest {
         lenient().when(activeOrderHandlerMock.canReleaseStanding(validOrder.getStandingAreaQuantities())).thenReturn(true);
 
         assertThrows(Exception.class, () ->
-                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID)
+                activeOrderService.completeOrder(paymentGatewayMock, VALID_SESSION, validPaymentDetails(), ORDER_ID, null)
         );
 
         verify(activeOrderPublisherMock, times(0)).publishReleaseSeats(VALID_TOKEN, ORDER_ID, EVENT_ID, List.of("B-10", "B-11"));


### PR DESCRIPTION
- made completeOrder() get the age in its parameters
- made a way to check only the tickets part of the policy of an event, this made me change the signature of publishIsUpToPolicy() in activeOrderPublisher
- made addSeatsToActiveOrder and addStandingToActiveOrder check only the tickets part of the policy of an event
- made updateOrder check only the tickets part of the policy of an event
- changed tests according to new completeOrder() and publishIsUpToPolicy() signatures